### PR TITLE
Fix a path in an example

### DIFF
--- a/caiman-test/programs/example.cair
+++ b/caiman-test/programs/example.cair
@@ -20,7 +20,7 @@ types [
 
 external_cpu i64 @do_thing_on_cpu(i64);
 // the path is required, and is relative to where you run this thing at the moment (unfortunately)
-external_gpu i64 @do_thing_on_gpu(%x : i64) : "caiman-test/src/programs/example.wgsl"
+external_gpu i64 @do_thing_on_gpu(%x : i64) : "caiman-test/programs/example.wgsl"
 {
     resource {
         group : 0,


### PR DESCRIPTION
Hello! I was trying to run this example, but Rust said:

```
thread 'main' panicked at 'Couldn't open caiman-test/src/programs/example.wgsl: No such file or directory (os error 2)', src/assembly/ast_to_ir.rs:415:21
```

I think this was just an outdated path embedded in the file. This seems to fix it!

(I'll elaborate on this on Slack, but after fixing that, I'm currently getting a different error.)