### PR TITLE
Use `cargo run` for Turnt command invocations

### DIFF
--- a/caiman-test/scheduling/turnt.toml
+++ b/caiman-test/scheduling/turnt.toml
@@ -1,5 +1,5 @@
 [envs.expected]
-command = "..\\..\\target\\debug\\caimanc.exe --input {base}_baseline.cair --explicate_only"
+command = "cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {base}_baseline.cair --explicate_only"
 
 [envs.explicate]
-command = "..\\..\\target\\debug\\caimanc.exe --input {filename} --explicate_only"
+command = "cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {filename} --explicate_only"


### PR DESCRIPTION
Just a very basic suggestion: the path to the executable was a Windows-style path, with `\` as the directory separator. This doesn't work on Unix. I could have just tweaked that (I think it would still work on Windows? not sure). But I went for a slightly fancier option: use `cargo run` to invoke the tool instead of invoking it directly. This way, doing `turnt trivial.cair` will rebuild the relevant executable if any of the Rust changes.