### PR TITLE
Refactor Arena

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -87,6 +87,38 @@ impl<T> Arena2<T> {
         };
         self.free_head = key;
     }
+
+    /// An iterator visiting all key-value pairs from lowest key to highest.
+    pub fn iter(&self) -> impl std::iter::Iterator<Item = (usize, &'_ T)> {
+        self.storage
+            .iter()
+            .filter_map(|entry| match entry {
+                Entry::Used { contents } => Some(contents),
+                Entry::Free { .. } => None,
+            })
+            .enumerate()
+    }
+    /// An iterator visiting all key-value pairs from lowest key to highest, with mutable references
+    /// to the values.
+    pub fn iter_mut(&mut self) -> impl std::iter::Iterator<Item = (usize, &'_ mut T)> {
+        self.storage
+            .iter_mut()
+            .filter_map(|entry| match entry {
+                Entry::Used { contents } => Some(contents),
+                Entry::Free { .. } => None,
+            })
+            .enumerate()
+    }
+}
+impl<T: std::default::Default> std::default::Default for Arena2<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Arena2<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1,148 +1,229 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::default::Default;
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
+
+/// A key used to access an element in the arena. Currently, this is just a `usize` index into a
+/// backing array, but this is an implementation detail and may eventually change. In particular
+/// this may become an opaque type which holds a generational index for bug-catching purposes.
+pub type Key = usize;
+const INVALID_KEY: Key = Key::MAX;
+
+#[derive(Clone)]
+enum Entry<T> {
+    /// An occupied entry.
+    Used {
+        /// The value contained by the entry.
+        contents: T,
+        // TODO: Should I implement a generational index for bug-catching? If added, I should make
+        // the raw index u32 and the generational index u32 so they can fit in a single 64 bit
+        // register, and specifically stick the generational index in the high 32 bits so it can be
+        // easily masked out for indexing. The generational index should live outside of the enum.
+    },
+    /// An unoccupied entry.
+    Free {
+        /// The index of the next free entry in the data structure's internal storage. This induces
+        /// a chain of free entries (a "free list"). The chain terminates when the contained value
+        /// is [`INVALID_KEY`] then it is the last entry in the chain.
+        next: Key,
+    },
+}
+
+/// From an API perspective
+#[derive(Clone)]
+pub struct Arena2<T> {
+    /// The backing storage for the entries.
+    storage: Vec<Entry<T>>,
+    /// The index of the head of the free list, or [`INVALID_KEY`] if all entries are used.
+    /// Invariants:
+    /// - This must be either the index of a free entry or [`INVALID_KEY`].
+    /// - The `nextFree` member of each entry in the free list must be either the index of a free
+    ///   entry or [`INVALID_KEY`].
+    free_head: Key,
+}
+impl<T> Arena2<T> {
+    /// Creates a new, empty [`Arena`]. Does not allocate until elements are added.
+    pub fn new() -> Self {
+        Self {
+            storage: Vec::new(),
+            free_head: INVALID_KEY,
+        }
+    }
+    /// Creates a new, empty [`Arena`] with enough space preallocated to hold `capacity` elements.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            storage: Vec::with_capacity(capacity),
+            free_head: INVALID_KEY,
+        }
+    }
+    /// Adds the specified element to the collection and returns an ID identifying it.
+    pub fn add(&mut self, element: T) -> Key {
+        // If self.free_head is the invalid key (indicating no free entries), this will return None,
+        // since the invalid key is greater than the maximum capacity of a Vec (isize::MAX)
+        if let Some(entry) = self.storage.get_mut(self.free_head) {
+            let key = self.free_head;
+            match entry {
+                Entry::Free { next } => self.free_head = *next,
+                Entry::Used { .. } => unreachable!(),
+            };
+            *entry = Entry::Used { contents: element };
+            return key;
+        } else {
+            let key = self.storage.len();
+            self.storage.push(Entry::Used { contents: element });
+            return key;
+        }
+    }
+    /// Removes the element at the specified key from the collection.
+    ///
+    /// # Panics
+    /// Panics if that element does not exist in the collection.
+    pub fn remove(&mut self, key: Key) {
+        let used = match self.storage.get_mut(key) {
+            Some(used @ Entry::Used { .. }) => used,
+            _ => panic!("element does not exist"),
+        };
+        *used = Entry::Free {
+            next: self.free_head,
+        };
+        self.free_head = key;
+    }
+}
 
 #[derive(Debug, Clone)]
-pub struct Arena<T>
-{
-	elements : HashMap<usize, T>,
-	unused_ids : Vec<usize>,
-	next_id : usize
+pub struct Arena<T> {
+    elements: HashMap<usize, T>,
+    unused_ids: Vec<usize>,
+    next_id: usize,
 }
 
-impl<T> Arena<T>
-{
-	pub fn new() -> Self
-	{
-		let mut unused_ids = Vec::<usize>::new();
-		let mut next_id : usize = 0;
-		Self{elements : HashMap::<usize, T>::new(), unused_ids, next_id}
-	}
+impl<T> Arena<T> {
+    pub fn new() -> Self {
+        let mut unused_ids = Vec::<usize>::new();
+        let mut next_id: usize = 0;
+        Self {
+            elements: HashMap::<usize, T>::new(),
+            unused_ids,
+            next_id,
+        }
+    }
 
-	pub fn from_hash_map(elements : HashMap<usize, T>) -> Self
-	{
-		let mut unused_ids = Vec::<usize>::new();
-		let mut next_id : usize = 0;
-		let mut element_count = elements.len();
-		while element_count > 0
-		{
-			// This might have a bug
-			if elements.contains_key(& next_id)
-			{
-				element_count -= 1;
-			}
-			else
-			{
-				unused_ids.push(next_id);
-			}
-			next_id += 1;
-		}
-		Self{elements, unused_ids, next_id}
-	}
+    pub fn from_hash_map(elements: HashMap<usize, T>) -> Self {
+        let mut unused_ids = Vec::<usize>::new();
+        let mut next_id: usize = 0;
+        let mut element_count = elements.len();
+        while element_count > 0 {
+            // This might have a bug
+            if elements.contains_key(&next_id) {
+                element_count -= 1;
+            } else {
+                unused_ids.push(next_id);
+            }
+            next_id += 1;
+        }
+        Self {
+            elements,
+            unused_ids,
+            next_id,
+        }
+    }
 
-	fn pop_unused_id(&mut self) -> usize
-	{
-		if let Some(id) = self.unused_ids.pop()
-		{
-			return id;
-		}
+    fn pop_unused_id(&mut self) -> usize {
+        if let Some(id) = self.unused_ids.pop() {
+            return id;
+        }
 
-		let id = self.next_id;
-		self.next_id += 1;
-		return id;
-	}
+        let id = self.next_id;
+        self.next_id += 1;
+        return id;
+    }
 
-	pub fn create(&mut self, value : T) -> usize
-	{
-		let id = self.pop_unused_id();
-		// Should check if there are no collisions for debugging
-		self.elements.insert(id, value);
-		id
-	}
+    pub fn create(&mut self, value: T) -> usize {
+        let id = self.pop_unused_id();
+        // Should check if there are no collisions for debugging
+        self.elements.insert(id, value);
+        id
+    }
 
-	pub fn iter<'m> (& 'm self) -> Iterator<'m, T>
-	{
-		Iterator::<'m, T>{iter : self.elements.iter()}
-	}
+    pub fn iter<'m>(&'m self) -> Iterator<'m, T> {
+        Iterator::<'m, T> {
+            iter: self.elements.iter(),
+        }
+    }
 
-	pub fn iter_mut<'m> (& 'm mut self) -> IteratorMut<'m, T>
-	{
-		IteratorMut::<'m, T>{iter : self.elements.iter_mut()}
-	}
+    pub fn iter_mut<'m>(&'m mut self) -> IteratorMut<'m, T> {
+        IteratorMut::<'m, T> {
+            iter: self.elements.iter_mut(),
+        }
+    }
 }
 
-impl <T> Default for Arena<T>
-{
-	fn default() -> Self
-	{
-		Self::from_hash_map(Default::default())
-	}
+impl<T> Default for Arena<T> {
+    fn default() -> Self {
+        Self::from_hash_map(Default::default())
+    }
 }
 
-impl<T> core::ops::Index<&usize> for Arena<T>
-{
-	type Output = T;
-	fn index(&self, index: &usize) -> &Self::Output
-	{
-		& self.elements.index(index)
-	}
+impl<T> core::ops::Index<&usize> for Arena<T> {
+    type Output = T;
+    fn index(&self, index: &usize) -> &Self::Output {
+        &self.elements.index(index)
+    }
 }
 
-impl<T> core::ops::IndexMut<&usize> for Arena<T>
-{
-	fn index_mut(&mut self, index: &usize) -> &mut Self::Output
-	{
-		self.elements.get_mut(index).unwrap()
-	}
+impl<T> core::ops::IndexMut<&usize> for Arena<T> {
+    fn index_mut(&mut self, index: &usize) -> &mut Self::Output {
+        self.elements.get_mut(index).unwrap()
+    }
 }
 
 impl<T> Serialize for Arena<T>
-	where T : Serialize
+where
+    T: Serialize,
 {
-	fn serialize<S>(& self, serializer : S) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-		where S : Serializer
-	{
-		self.elements.serialize(serializer)
-	}
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        self.elements.serialize(serializer)
+    }
 }
 
 impl<'de, T> Deserialize<'de> for Arena<T>
-	where T : Deserialize<'de>
+where
+    T: Deserialize<'de>,
 {
-	fn deserialize<D>(deserializer : D) -> std::result::Result<Self, <D as Deserializer<'de>>::Error>
-		where D : Deserializer<'de>
-	{
-		let elements = HashMap::<usize, T>::deserialize(deserializer)?;
-		Ok(Self::from_hash_map(elements))
-	}
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let elements = HashMap::<usize, T>::deserialize(deserializer)?;
+        Ok(Self::from_hash_map(elements))
+    }
 }
 
-pub struct Iterator<'m, T>
-{
-	iter : std::collections::hash_map::Iter<'m, usize, T>
+pub struct Iterator<'m, T> {
+    iter: std::collections::hash_map::Iter<'m, usize, T>,
 }
 
-impl<'m, T> std::iter::Iterator for Iterator<'m, T>
-{
-	type Item = (& 'm usize, & 'm T);
+impl<'m, T> std::iter::Iterator for Iterator<'m, T> {
+    type Item = (&'m usize, &'m T);
 
-	fn next(&mut self) -> Option<Self::Item>
-	{
-		self.iter.next()
-	}
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
 }
 
-pub struct IteratorMut<'m, T>
-{
-	iter : std::collections::hash_map::IterMut<'m, usize, T>
+pub struct IteratorMut<'m, T> {
+    iter: std::collections::hash_map::IterMut<'m, usize, T>,
 }
 
-impl<'m, T> std::iter::Iterator for IteratorMut<'m, T>
-{
-	type Item = (& 'm usize, & 'm mut T);
+impl<'m, T> std::iter::Iterator for IteratorMut<'m, T> {
+    type Item = (&'m usize, &'m mut T);
 
-	fn next(&mut self) -> Option<Self::Item>
-	{
-		self.iter.next()
-	}
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
 }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -87,7 +87,20 @@ impl<T> Arena2<T> {
         };
         self.free_head = key;
     }
-
+    /// Returns an immutable reference to an element, or None if the index is out of bounds.
+    pub fn get(&self, key: Key) -> Option<&'_ T> {
+        match self.storage.get(key) {
+            Some(Entry::Used { contents }) => Some(contents),
+            _ => None,
+        }
+    }
+    /// Returns a mutable reference to an element, or None if the index is out of bounds.
+    pub fn get_mut(&mut self, key: Key) -> Option<&'_ mut T> {
+        match self.storage.get_mut(key) {
+            Some(Entry::Used { contents }) => Some(contents),
+            _ => None,
+        }
+    }
     /// An iterator visiting all key-value pairs from lowest key to highest.
     pub fn iter(&self) -> impl std::iter::Iterator<Item = (usize, &'_ T)> {
         self.storage
@@ -118,6 +131,23 @@ impl<T: std::default::Default> std::default::Default for Arena2<T> {
 impl<T: std::fmt::Debug> std::fmt::Debug for Arena2<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map().entries(self.iter()).finish()
+    }
+}
+impl<T> core::ops::Index<&Key> for Arena2<T> {
+    type Output = T;
+    fn index(&self, key: &Key) -> &Self::Output {
+        match self.storage.get(*key) {
+            Some(Entry::Used { contents }) => contents,
+            _ => panic!("invalid index"),
+        }
+    }
+}
+impl<T> core::ops::IndexMut<&Key> for Arena2<T> {
+    fn index_mut(&mut self, key: &Key) -> &mut Self::Output {
+        match self.storage.get_mut(*key) {
+            Some(Entry::Used { contents }) => contents,
+            _ => panic!("invalid index"),
+        }
     }
 }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -3,7 +3,7 @@ use std::default::Default;
 //use serde::{Serialize, Deserialize};
 use serde_derive::{Serialize, Deserialize};
 //use bitflags::bitflags;
-use crate::arena::Arena;
+use crate::stable_vec::StableVec;
 
 pub use crate::rust_wgpu_backend::ffi as ffi;
 
@@ -321,11 +321,11 @@ pub struct Program
 	#[serde(default)]
 	pub native_interface : ffi::NativeInterface,
 	#[serde(default)]
-	pub types : Arena<Type>,
+	pub types : StableVec<Type>,
 	#[serde(default)]
-	pub funclets : Arena<Funclet>,
+	pub funclets : StableVec<Funclet>,
 	#[serde(default)]
-	pub value_functions : Arena<ValueFunction>,
+	pub value_functions : StableVec<ValueFunction>,
 	#[serde(default)]
 	pub pipelines : Vec<Pipeline>,
 	#[serde(default)]

--- a/src/ir/validation.rs
+++ b/src/ir/validation.rs
@@ -72,7 +72,7 @@ pub fn validate_timeline_funclet(program : & ir::Program, funclet : & ir::Funcle
 
 	for (input_index, input_type) in funclet.input_types.iter().enumerate()
 	{
-		match & program.types[input_type]
+		match & program.types[*input_type]
 		{
 			ir::Type::Event{place} => assert_eq!(* place, ir::Place::Local),
 			_ => panic!("Timeline funclet's input #{} has an unsupported type: #{}", input_index, input_type)
@@ -81,7 +81,7 @@ pub fn validate_timeline_funclet(program : & ir::Program, funclet : & ir::Funcle
 
 	for (output_index, output_type) in funclet.output_types.iter().enumerate()
 	{
-		match & program.types[output_type]
+		match & program.types[*output_type]
 		{
 			ir::Type::Event{place} => assert_eq!(* place, ir::Place::Local),
 			_ => panic!("Timeline funclet's output #{} has an unsupported type: #{}", output_index, output_type)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 mod operations;
 mod id_generator;
-mod arena;
+mod stable_vec;
 mod ir;
 //mod ir_builders;
 mod shadergen;

--- a/src/rust_wgpu_backend/code_generator.rs
+++ b/src/rust_wgpu_backend/code_generator.rs
@@ -273,7 +273,7 @@ impl<'program> CodeGenerator<'program>
 	{
 		let mut output_vars = Vec::<VarId>::new();
 
-		let external_gpu_function = & self.native_interface.external_gpu_functions[& external_function_id];
+		let external_gpu_function = & self.native_interface.external_gpu_functions[external_function_id];
 		for (output_index, output_type_id) in external_gpu_function.output_types.iter().enumerate()
 		{
 			let variable_id = self.variable_tracker.create_buffer(* output_type_id);
@@ -324,7 +324,7 @@ impl<'program> CodeGenerator<'program>
 
 		if ! self.shader_modules.contains_key(& shader_module_key)
 		{
-			let external_gpu_function = & self.native_interface.external_gpu_functions[& external_function_id];
+			let external_gpu_function = & self.native_interface.external_gpu_functions[external_function_id];
 	
 			let mut shader_module = match & external_gpu_function.shader_module_content
 			{
@@ -349,7 +349,7 @@ impl<'program> CodeGenerator<'program>
 	fn set_active_bindings(&mut self, argument_vars : &[VarId], output_vars : &[VarId])// -> Box<[usize]>
 	{
 		let external_function_id = self.active_external_gpu_function_id.unwrap();
-		let external_gpu_function = & self.native_interface.external_gpu_functions[& external_function_id];
+		let external_gpu_function = & self.native_interface.external_gpu_functions[external_function_id];
 
 		let mut bindings = std::collections::BTreeMap::<usize, (Option<usize>, Option<usize>)>::new();
 		let mut output_binding_map = std::collections::BTreeMap::<usize, usize>::new();
@@ -518,7 +518,7 @@ impl<'program> CodeGenerator<'program>
 		
 		self.begin_command_encoding();
 
-		let external_gpu_function = & self.native_interface.external_gpu_functions[& external_function_id];
+		let external_gpu_function = & self.native_interface.external_gpu_functions[external_function_id];
 		assert_eq!(external_gpu_function.input_types.len(), argument_vars.len());
 		//let mut output_variables = Vec::<usize>::new();
 		self.code_writer.write(format!("let ("));
@@ -859,7 +859,7 @@ impl<'program> CodeGenerator<'program>
 			let variable_id = self.variable_tracker.create_local_data(* input_type);
 			argument_variable_ids.push(variable_id);
 			let type_name = self.get_type_name(*input_type);
-			let is_mutable = match & self.native_interface.types[& input_type.0]
+			let is_mutable = match & self.native_interface.types[input_type.0]
 			{
 				ffi::Type::GpuBufferAllocator => true,
 				_ => false
@@ -1357,7 +1357,7 @@ impl<'program> CodeGenerator<'program>
 
 		self.has_been_generated.insert(type_id);
 
-		let typ = & self.native_interface.types[& type_id.0];
+		let typ = & self.native_interface.types[type_id.0];
 		write!(self.type_code_writer, "// Type #{}: {:?}\n", type_id.0, typ);
 		match typ
 		{
@@ -1422,7 +1422,7 @@ impl<'program> CodeGenerator<'program>
 
 	fn get_type_name(& self, type_id : ffi::TypeId) -> String
 	{
-		match & self.native_interface.types[& type_id.0]
+		match & self.native_interface.types[type_id.0]
 		{
 			ffi::Type::F32 => "f32".to_string(),
 			ffi::Type::F64 => "f64".to_string(),
@@ -1702,7 +1702,7 @@ impl<'program> CodeGenerator<'program>
 
 	pub fn build_external_cpu_function_call(&mut self, external_function_id : ir::ExternalCpuFunctionId, argument_vars : &[VarId]) -> Box<[VarId]>
 	{
-		let external_cpu_function = & self.native_interface.external_cpu_functions[& external_function_id];
+		let external_cpu_function = & self.native_interface.external_cpu_functions[external_function_id];
 		let call_result_var = self.variable_tracker.generate();
 		let mut argument_string = String::new();
 		for (index, argument) in argument_vars.iter().enumerate()

--- a/src/rust_wgpu_backend/code_generator.rs
+++ b/src/rust_wgpu_backend/code_generator.rs
@@ -1,6 +1,6 @@
 use crate::ir;
 use crate::shadergen;
-use crate::arena::Arena;
+use crate::stable_vec::StableVec;
 use std::default::Default;
 use std::collections::HashMap;
 use std::collections::BTreeMap;

--- a/src/rust_wgpu_backend/code_generator.rs
+++ b/src/rust_wgpu_backend/code_generator.rs
@@ -241,7 +241,7 @@ impl<'program> CodeGenerator<'program>
 		let has_been_generated = HashSet::new();
 		let mut code_generator = Self {original_native_interface : native_interface, native_interface : native_interface.clone(), type_code_writer, state_code_writer, code_writer, /*types,*/ has_been_generated, variable_tracker, /*external_cpu_functions, external_gpu_functions,*/ active_pipeline_name : None, active_funclet_result_type_ids : None, active_funclet_state : None, use_recording : true, active_submission_encoding_state : None, active_external_gpu_function_id : None, active_shader_module_key : None, shader_modules : BTreeMap::new(), submission_queue : Default::default(), next_command_buffer_id : CommandBufferId(0), gpu_function_invocations : Vec::new(), active_closures : HashMap::new(), closure_id_generator : IdGenerator::new(), active_yield_point_ids : HashSet::new(), dispatcher_id_generator : IdGenerator::new(), active_dispatchers : HashMap::new()};
 
-		let type_ids = code_generator.native_interface.types.iter().map(|(type_id, _)| ffi::TypeId(* type_id)).collect::<Box<[ffi::TypeId]>>();
+		let type_ids = code_generator.native_interface.types.iter().map(|(type_id, _)| ffi::TypeId(type_id)).collect::<Box<[ffi::TypeId]>>();
 		for & type_id in type_ids.iter()
 		{
 			code_generator.generate_type_definition(type_id);
@@ -692,7 +692,7 @@ impl<'program> CodeGenerator<'program>
 				{
 					tuple_fields.push(*output_type);
 				}
-				//let type_id = self.native_interface.types.create(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
+				//let type_id = self.native_interface.types.add(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
 				//self.generate_type_definition(ffi::TypeId(type_id));
 				//write!(self.code_writer, "pub type {} = super::super::{};\n", external_cpu_function.name, self.get_type_name(ffi::TypeId(type_id)));
 				write!(self.code_writer, "pub type {} = {};\n", external_cpu_function.name, self.get_tuple_definition_string(tuple_fields.as_slice()));
@@ -725,7 +725,7 @@ impl<'program> CodeGenerator<'program>
 				tuple_fields.push(output_type);
 				self.generate_type_definition(output_type);
 			}
-			let type_id = self.native_interface.types.create(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
+			let type_id = self.native_interface.types.add(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
 			self.generate_type_definition(type_id);
 			write!(self.code_writer, "pub type {} = super::super::{};\n", self.active_pipeline_name.as_ref().unwrap().as_str(), self.get_type_name(type_id));
 		}
@@ -769,7 +769,7 @@ impl<'program> CodeGenerator<'program>
 				//self.generate_type_definition(output_type);
 				tuple_fields.push(output_type);
 			}
-			/*let type_id = self.native_interface.types.create(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
+			/*let type_id = self.native_interface.types.add(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
 			self.generate_type_definition(ffi::TypeId(type_id));
 			//write!(self.code_writer, "pub type {} = super::super::{};\n", self.active_pipeline_name.as_ref().unwrap().as_str(), self.get_type_name(type_id));
 			type_id*/
@@ -892,7 +892,7 @@ impl<'program> CodeGenerator<'program>
 				let output_type = output_types[output_index];
 				tuple_fields.push(output_type);
 			}
-			//let type_id = self.native_interface.types.create(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
+			//let type_id = self.native_interface.types.add(ffi::Type::Tuple{fields : tuple_fields.into_boxed_slice()});
 			//self.generate_type_definition(type_id);
 			write!(self.code_writer, "pub type {} = {};\n", self.active_pipeline_name.as_ref().unwrap().as_str(), self.get_tuple_definition_string(tuple_fields.as_slice()));
 		}
@@ -1476,7 +1476,7 @@ impl<'program> CodeGenerator<'program>
 
 	pub fn create_ffi_type(&mut self, typ : ffi::Type) -> ffi::TypeId
 	{
-		let type_id = ffi::TypeId(self.native_interface.types.create(typ));
+		let type_id = ffi::TypeId(self.native_interface.types.add(typ));
 		self.generate_type_definition(type_id);
 		type_id
 	}

--- a/src/rust_wgpu_backend/codegen.rs
+++ b/src/rust_wgpu_backend/codegen.rs
@@ -273,8 +273,8 @@ impl FuncletScopedState
 
 fn check_storage_type_implements_value_type(program : & ir::Program, storage_type_id : ir::ffi::TypeId, value_type_id : ir::TypeId)
 {
-	let storage_type = & program.native_interface.types[& storage_type_id.0];
-	let value_type = & program.types[& value_type_id];
+	let storage_type = & program.native_interface.types[storage_type_id.0];
+	let value_type = & program.types[value_type_id];
 	/*match value_type
 	{
 		ir::Type::Integer{signed, width} =>
@@ -345,7 +345,7 @@ impl<'program> CodeGen<'program>
 			return * ffi_type_id;
 		}
 
-		let typ = & self.program.types[& type_id];
+		let typ = & self.program.types[type_id];
 		let ffi_type_id = match typ
 		{
 			ir::Type::Slot { storage_type, queue_stage : _, queue_place : ir::Place::Local } =>
@@ -355,7 +355,7 @@ impl<'program> CodeGen<'program>
 			}
 			ir::Type::Slot { storage_type, queue_stage : _, queue_place : ir::Place::Gpu} =>
 			{
-				match & self.program.native_interface.types[& storage_type.0]
+				match & self.program.native_interface.types[storage_type.0]
 				{
 					ir::ffi::Type::ErasedLengthArray{element_type} =>
 					{
@@ -385,7 +385,7 @@ impl<'program> CodeGen<'program>
 		{
 			ir::Node::CallExternalGpuCompute {external_function_id, arguments, dimensions} =>
 			{
-				let function = & self.program.native_interface.external_gpu_functions[external_function_id];
+				let function = & self.program.native_interface.external_gpu_functions[*external_function_id];
 
 				assert_eq!(input_slot_ids.len(), dimensions.len() + arguments.len());
 				assert_eq!(output_slot_ids.len(), function.output_types.len());
@@ -534,7 +534,7 @@ impl<'program> CodeGen<'program>
 			}
 			ir::Node::CallExternalCpu { external_function_id, arguments } =>
 			{
-				let function = & self.program.native_interface.external_cpu_functions[external_function_id];
+				let function = & self.program.native_interface.external_cpu_functions[*external_function_id];
 
 				use std::iter::FromIterator;
 
@@ -612,7 +612,7 @@ impl<'program> CodeGen<'program>
 		let mut input_storage_types = Vec::<ir::ffi::TypeId>::new();
 		let mut output_storage_types = Vec::<ir::ffi::TypeId>::new();
 		let mut capture_var_ids = Vec::<VarId>::new();
-		let join_point_scheduling_funclet = & self.program.funclets[& funclet_id];
+		let join_point_scheduling_funclet = & self.program.funclets[funclet_id];
 		for (capture_index, captured_node_result) in captures.iter().enumerate()
 		{
 			let var_id = placement_state.get_node_result_var_id(& captured_node_result).unwrap();
@@ -642,7 +642,7 @@ impl<'program> CodeGen<'program>
 
 	fn compile_externally_visible_scheduling_funclet(&mut self, funclet_id : ir::FuncletId, pipeline_context : &mut PipelineContext)
 	{
-		let funclet = & self.program.funclets[& funclet_id];
+		let funclet = & self.program.funclets[funclet_id];
 		assert_eq!(funclet.kind, ir::FuncletKind::ScheduleExplicit);
 		let funclet_extra = & self.program.scheduling_funclet_extras[& funclet_id];
 
@@ -659,7 +659,7 @@ impl<'program> CodeGen<'program>
 			{
 				use ir::Type;
 				
-				match & self.program.types[input_type_id]
+				match & self.program.types[*input_type_id]
 				{
 					ir::Type::Slot { storage_type, queue_stage, queue_place } =>
 					{
@@ -806,7 +806,7 @@ impl<'program> CodeGen<'program>
 							TraversalState::SelectIf { branch_input_node_results, condition_slot_id, true_funclet_id, false_funclet_id, continuation_join_point_id_opt } =>
 							{
 								let condition_var_id = placement_state.get_slot_var_id(condition_slot_id).unwrap();
-								let true_funclet = & self.program.funclets[& true_funclet_id];
+								let true_funclet = & self.program.funclets[true_funclet_id];
 								let true_funclet_extra = & self.program.scheduling_funclet_extras[& true_funclet_id];
 								//true_funclet_extra.input_slots[& output_index].value_tag
 								let output_types = true_funclet.output_types.iter().map(|type_id| self.get_cpu_useable_type(* type_id)).collect::<Box<[ir::ffi::TypeId]>>();
@@ -815,7 +815,7 @@ impl<'program> CodeGen<'program>
 								for (output_index, output_type) in true_funclet.output_types.iter().enumerate()
 								{
 									// Joins capture by slot.  This is ok because joins can't escape the scope they were created in.  We'll reach None before leaving the scope.
-									let (storage_type, queue_stage, queue_place) = if let ir::Type::Slot{storage_type, queue_stage, queue_place} = & self.program.types[output_type]
+									let (storage_type, queue_stage, queue_place) = if let ir::Type::Slot{storage_type, queue_stage, queue_place} = & self.program.types[*output_type]
 									{
 										(* storage_type, * queue_stage, * queue_place)
 									}
@@ -846,7 +846,7 @@ impl<'program> CodeGen<'program>
 							}
 							TraversalState::DynAllocIf { buffer_node_result, success_funclet_id, failure_funclet_id, argument_node_results, dynamic_allocation_size_slot_ids, continuation_join_point_id_opt} =>
 							{
-								let success_funclet = & self.program.funclets[& success_funclet_id];
+								let success_funclet = & self.program.funclets[success_funclet_id];
 								let success_funclet_extra = & self.program.scheduling_funclet_extras[& success_funclet_id];
 
 								let (buffer_var_id, condition_var_id) = 
@@ -866,7 +866,7 @@ impl<'program> CodeGen<'program>
 								success_argument_node_results.extend_from_slice(& argument_node_results);
 								for (index, slot_id_opt) in dynamic_allocation_size_slot_ids.iter().enumerate()
 								{
-									let node_result = match & self.program.types[& success_funclet.input_types[argument_node_results.len() + index]]
+									let node_result = match & self.program.types[success_funclet.input_types[argument_node_results.len() + index]]
 									{
 										ir::Type::Slot{queue_stage, queue_place, storage_type} =>
 										{
@@ -874,7 +874,7 @@ impl<'program> CodeGen<'program>
 											let var_id =
 												if let Some(slot_id) = slot_id_opt
 												{
-													match & self.program.native_interface.types[& storage_type.0]
+													match & self.program.native_interface.types[storage_type.0]
 													{
 														ir::ffi::Type::ErasedLengthArray{element_type} =>
 														{
@@ -905,7 +905,7 @@ impl<'program> CodeGen<'program>
 								let mut output_node_results = Vec::<NodeResult>::new();
 								for (output_index, output_type) in success_funclet.output_types.iter().enumerate()
 								{
-									match & self.program.types[output_type]
+									match & self.program.types[*output_type]
 									{
 										ir::Type::Slot{storage_type, queue_stage, queue_place} => 
 										{
@@ -983,7 +983,7 @@ impl<'program> CodeGen<'program>
 
 	fn compile_scheduling_funclet(&mut self, funclet_id : ir::FuncletId, argument_node_results : &[NodeResult], /*argument_slot_ids : &[SlotId],*/ pipeline_context : &mut PipelineContext, placement_state : &mut PlacementState, mut default_join_point_id_opt : Option<JoinPointId>) -> SplitPoint //Box<[SlotId]>
 	{
-		let funclet = & self.program.funclets[& funclet_id];
+		let funclet = & self.program.funclets[funclet_id];
 		assert_eq!(funclet.kind, ir::FuncletKind::ScheduleExplicit);
 		let funclet_scheduling_extra = & self.program.scheduling_funclet_extras[& funclet_id];
 		//let scheduled_value_funclet = & self.program.value_funclets[& scheduling_funclet.value_funclet_id];
@@ -1066,7 +1066,7 @@ impl<'program> CodeGen<'program>
 					let mut input_slot_ids = Vec::<SlotId>::new();
 					let mut output_slot_ids = Vec::<SlotId>::new();
 
-					let encoded_funclet = & self.program.funclets[& operation.funclet_id];
+					let encoded_funclet = & self.program.funclets[operation.funclet_id];
 					let encoded_node = & encoded_funclet.nodes[operation.node_id];
 
 					for & input_node_id in inputs.iter()
@@ -1224,7 +1224,7 @@ impl<'program> CodeGen<'program>
 				ir::Node::InlineJoin { funclet : funclet_id, captures, continuation : continuation_join_node_id } => 
 				{
 					let mut captured_node_results = Vec::<NodeResult>::new();
-					let join_funclet = & self.program.funclets[funclet_id];
+					let join_funclet = & self.program.funclets[*funclet_id];
 					let extra = & self.program.scheduling_funclet_extras[funclet_id];
 
 					// Join points can only be constructed for the value funclet they are created in
@@ -1245,7 +1245,7 @@ impl<'program> CodeGen<'program>
 				ir::Node::SerializedJoin { funclet : funclet_id, captures, continuation : continuation_join_node_id } => 
 				{
 					let mut captured_node_results = Vec::<NodeResult>::new();
-					let join_funclet = & self.program.funclets[funclet_id];
+					let join_funclet = & self.program.funclets[*funclet_id];
 					let extra = & self.program.scheduling_funclet_extras[funclet_id];
 
 					// Join points can only be constructed for the value funclet they are created in
@@ -1284,7 +1284,7 @@ impl<'program> CodeGen<'program>
 			ir::TailEdge::Return { return_values } =>
 			{
 				let encoded_value_funclet_id = funclet_scheduling_extra.value_funclet_id;
-				let encoded_value_funclet = & self.program.funclets[& encoded_value_funclet_id];
+				let encoded_value_funclet = & self.program.funclets[encoded_value_funclet_id];
 
 				let mut output_node_results = Vec::<NodeResult>::new();
 
@@ -1316,7 +1316,7 @@ impl<'program> CodeGen<'program>
 					argument_node_results.push(node_result);
 				}
 
-				let join_funclet = & self.program.funclets[next_funclet_id];
+				let join_funclet = & self.program.funclets[*next_funclet_id];
 				let join_extra = & self.program.scheduling_funclet_extras[next_funclet_id];
 				let join_point_id = placement_state.join_graph.create(JoinPoint::SimpleJoinPoint(SimpleJoinPoint{value_funclet_id : join_extra.value_funclet_id, scheduling_funclet_id : * next_funclet_id, captures : argument_node_results.into_boxed_slice(), continuation_join_point_id}));
 				SplitPoint::Yield{pipeline_yield_point_id : * pipeline_yield_point_id, yielded_node_results : output_node_results.into_boxed_slice(), continuation_join_point_id_opt : Some(join_point_id)}
@@ -1368,11 +1368,11 @@ impl<'program> CodeGen<'program>
 				assert_eq!(value_operation.funclet_id, funclet_scoped_state.value_funclet_id);
 				//assert_eq!(continuation_join_point.get_value_funclet_id(), funclet_scoped_state.value_funclet_id);
 
-				let callee_funclet = & self.program.funclets[& callee_scheduling_funclet_id];
+				let callee_funclet = & self.program.funclets[callee_scheduling_funclet_id];
 				assert_eq!(callee_funclet.kind, ir::FuncletKind::ScheduleExplicit);
 				let callee_funclet_scheduling_extra = & self.program.scheduling_funclet_extras[& callee_scheduling_funclet_id];
 				let callee_value_funclet_id = callee_funclet_scheduling_extra.value_funclet_id;
-				let callee_value_funclet = & self.program.funclets[& callee_value_funclet_id];
+				let callee_value_funclet = & self.program.funclets[callee_value_funclet_id];
 				assert_eq!(callee_value_funclet.kind, ir::FuncletKind::Value);
 
 				let mut argument_node_results = Vec::<NodeResult>::new();
@@ -1398,12 +1398,12 @@ impl<'program> CodeGen<'program>
 				assert_eq!(callee_funclet_ids.len(), 2);
 				let true_funclet_id = callee_funclet_ids[0];
 				let false_funclet_id = callee_funclet_ids[1];
-				let true_funclet = & self.program.funclets[& true_funclet_id];
-				let false_funclet = & self.program.funclets[& false_funclet_id];
+				let true_funclet = & self.program.funclets[true_funclet_id];
+				let false_funclet = & self.program.funclets[false_funclet_id];
 				let true_funclet_extra = & self.program.scheduling_funclet_extras[& true_funclet_id];
 				let false_funclet_extra = & self.program.scheduling_funclet_extras[& false_funclet_id];
 
-				let current_value_funclet = & self.program.funclets[& value_operation.funclet_id];
+				let current_value_funclet = & self.program.funclets[value_operation.funclet_id];
 				assert_eq!(current_value_funclet.kind, ir::FuncletKind::Value);
 
 				assert_eq!(value_operation.funclet_id, true_funclet_extra.value_funclet_id);
@@ -1431,8 +1431,8 @@ impl<'program> CodeGen<'program>
 
 				let true_funclet_id = success_funclet_id;
 				let false_funclet_id = failure_funclet_id;
-				let true_funclet = & self.program.funclets[& true_funclet_id];
-				let false_funclet = & self.program.funclets[& false_funclet_id];
+				let true_funclet = & self.program.funclets[*true_funclet_id];
+				let false_funclet = & self.program.funclets[*false_funclet_id];
 				let true_funclet_extra = & self.program.scheduling_funclet_extras[& true_funclet_id];
 				let false_funclet_extra = & self.program.scheduling_funclet_extras[& false_funclet_id];
 
@@ -1486,7 +1486,7 @@ impl<'program> CodeGen<'program>
 		let entry_funclet_id : ir::FuncletId = pipeline.entry_funclet;
 		let pipeline_name : &str = pipeline.name.as_str();
 
-		let entry_funclet = & self.program.funclets[& entry_funclet_id];
+		let entry_funclet = & self.program.funclets[entry_funclet_id];
 		assert_eq!(entry_funclet.kind, ir::FuncletKind::ScheduleExplicit);
 
 		let mut pipeline_context = PipelineContext::new();

--- a/src/rust_wgpu_backend/codegen.rs
+++ b/src/rust_wgpu_backend/codegen.rs
@@ -1,6 +1,6 @@
 use crate::ir;
 use crate::shadergen;
-use crate::arena::Arena;
+use crate::stable_vec::StableVec;
 use std::default::Default;
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/src/rust_wgpu_backend/explicate_scheduling.rs
+++ b/src/rust_wgpu_backend/explicate_scheduling.rs
@@ -2,7 +2,7 @@ use crate::ir;
 //use crate::ir_builders;
 
 use crate::shadergen;
-use crate::arena::Arena;
+use crate::stable_vec::StableVec;
 use std::default::Default;
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/src/rust_wgpu_backend/ffi.rs
+++ b/src/rust_wgpu_backend/ffi.rs
@@ -124,7 +124,7 @@ impl NativeInterface
 
 	pub fn calculate_type_binding_info(&self, type_id : TypeId) -> TypeBindingInfo
 	{
-		match & self.types[& type_id.0]
+		match & self.types[type_id.0]
 		{
 			Type::F32 => TypeBindingInfo { size : std::mem::size_of::<f32>(), alignment : std::mem::align_of::<f32>() },
 			Type::F64 => TypeBindingInfo { size : std::mem::size_of::<f64>(), alignment : std::mem::align_of::<f64>() },

--- a/src/rust_wgpu_backend/ffi.rs
+++ b/src/rust_wgpu_backend/ffi.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Serialize, Deserialize};
-use crate::arena::Arena;
+use crate::stable_vec::StableVec;
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Default, Hash)]
 pub struct TypeId(pub usize); // temporarily exposed internals
@@ -105,11 +105,11 @@ impl ExternalGpuFunction
 pub struct NativeInterface
 {
 	#[serde(default)]
-	pub types : Arena<Type>,
+	pub types : StableVec<Type>,
 	#[serde(default)]
-	pub external_cpu_functions : Arena<ExternalCpuFunction>,
+	pub external_cpu_functions : StableVec<ExternalCpuFunction>,
 	#[serde(default)]
-	pub external_gpu_functions : Arena<ExternalGpuFunction>,
+	pub external_gpu_functions : StableVec<ExternalGpuFunction>,
 }
 
 pub struct TypeBindingInfo

--- a/src/scheduling_state.rs
+++ b/src/scheduling_state.rs
@@ -181,42 +181,42 @@ impl SchedulingState
 
 	pub fn get_slot_type_id(&self, slot_id : SlotId) -> ir::ffi::TypeId
 	{
-		self.slots[& slot_id.0].type_id
+		self.slots[slot_id.0].type_id
 	}
 
 	pub fn get_slot_queue_stage(&self, slot_id : SlotId) -> ir::ResourceQueueStage
 	{
-		self.slots[& slot_id.0].queue_stage
+		self.slots[slot_id.0].queue_stage
 	}
 
 	pub fn get_slot_queue_place(&self, slot_id : SlotId) -> ir::Place
 	{
-		self.slots[& slot_id.0].queue_place
+		self.slots[slot_id.0].queue_place
 	}
 
 	pub fn get_slot_queue_timestamp(&self, slot_id : SlotId) -> LogicalTimestamp
 	{
-		self.slots[& slot_id.0].timestamp
+		self.slots[slot_id.0].timestamp
 	}
 
 	pub fn discard_slot(&mut self, slot_id : SlotId)
 	{
-		let slot = &mut self.slots[& slot_id.0];
+		let slot = &mut self.slots[slot_id.0];
 		assert!(slot.queue_stage < ir::ResourceQueueStage::Dead);
 		slot.queue_stage = ir::ResourceQueueStage::Dead;
 	}
 
 	pub fn forward_slot(&mut self, destination_slot_id : SlotId, source_slot_id : SlotId)
 	{
-		assert!(self.slots[& source_slot_id.0].queue_stage < ir::ResourceQueueStage::Dead);
-		assert!(self.slots[& destination_slot_id.0].queue_stage == ir::ResourceQueueStage::Unbound);
-		self.slots[& destination_slot_id.0].queue_stage = ir::ResourceQueueStage::Bound;
-		self.slots[& source_slot_id.0].queue_stage = ir::ResourceQueueStage::Dead;
+		assert!(self.slots[source_slot_id.0].queue_stage < ir::ResourceQueueStage::Dead);
+		assert!(self.slots[destination_slot_id.0].queue_stage == ir::ResourceQueueStage::Unbound);
+		self.slots[destination_slot_id.0].queue_stage = ir::ResourceQueueStage::Bound;
+		self.slots[source_slot_id.0].queue_stage = ir::ResourceQueueStage::Dead;
 	}
 
 	pub fn advance_queue_stage(&mut self, slot_id : SlotId, to : ir::ResourceQueueStage)
 	{
-		let slot = &mut self.slots[& slot_id.0];
+		let slot = &mut self.slots[slot_id.0];
 		assert!(slot.queue_stage <= to);
 		slot.queue_stage = to;
 	}

--- a/src/scheduling_state.rs
+++ b/src/scheduling_state.rs
@@ -121,7 +121,7 @@ impl SchedulingState
 	{
 		let timestamp = self.get_local_time();
 		let slot = Slot{type_id, value_tag_opt : None, /*value_instance_id_opt : None,*/ timestamp, queue_place, queue_stage, state_binding : StateBinding::TemporaryHack};
-		SlotId(self.slots.create(slot))
+		SlotId(self.slots.add(slot))
 	}
 
 	/*pub fn bind_slot_value(&mut self, slot_id : SlotId, value_tag_opt : Option<ir::ValueTag>, value_instance_id_opt : Option<ValueInstanceId>)
@@ -139,7 +139,7 @@ impl SchedulingState
 	/*pub fn insert_value_instance(&mut self) -> ValueInstanceId
 	{
 		use std::iter::FromIterator;
-		ValueInstanceId(self.value_instances.create(ValueInstance{}))
+		ValueInstanceId(self.value_instances.add(ValueInstance{}))
 	}*/
 
 	pub fn insert_submission<Listener>(&mut self, queue_place : ir::Place, listener : &mut Listener) -> SubmissionId
@@ -165,7 +165,7 @@ impl SchedulingState
 			}
 		}
 
-		SubmissionId(self.submissions.create(Submission{queue_place, timestamp}))
+		SubmissionId(self.submissions.add(Submission{queue_place, timestamp}))
 	}
 
 

--- a/src/scheduling_state.rs
+++ b/src/scheduling_state.rs
@@ -1,5 +1,5 @@
 use crate::ir;
-use crate::arena::Arena;
+use crate::stable_vec::StableVec;
 use std::default::Default;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -96,9 +96,9 @@ struct PlaceState
 pub struct SchedulingState
 {
 	place_states : HashMap<ir::Place, PlaceState>, // as known to the coordinator
-	slots : Arena<Slot>,
+	slots : StableVec<Slot>,
 	//value_instances : Arena<ValueInstance>,
-	submissions : Arena<Submission>
+	submissions : StableVec<Submission>
 }
 
 #[derive(Debug)]

--- a/src/stable_vec.rs
+++ b/src/stable_vec.rs
@@ -133,21 +133,15 @@ impl<T: std::fmt::Debug> std::fmt::Debug for StableVec<T> {
         f.debug_map().entries(self.iter()).finish()
     }
 }
-impl<T> core::ops::Index<&Key> for StableVec<T> {
+impl<T> core::ops::Index<Key> for StableVec<T> {
     type Output = T;
-    fn index(&self, key: &Key) -> &Self::Output {
-        self.storage
-            .get(*key)
-            .and_then(Entry::used)
-            .expect("invalid index")
+    fn index(&self, key: Key) -> &Self::Output {
+        self.get(key).expect("invalid index")
     }
 }
-impl<T> core::ops::IndexMut<&Key> for StableVec<T> {
-    fn index_mut(&mut self, key: &Key) -> &mut Self::Output {
-        self.storage
-            .get_mut(*key)
-            .and_then(Entry::used_mut)
-            .expect("invalid index")
+impl<T> core::ops::IndexMut<Key> for StableVec<T> {
+    fn index_mut(&mut self, key: Key) -> &mut Self::Output {
+        self.get_mut(key).expect("invalid index")
     }
 }
 impl<T: Serialize> Serialize for StableVec<T> {
@@ -192,7 +186,7 @@ where
             if needed_len >= storage.len() {
                 storage.resize(needed_len, Entry::Free { next: INVALID_KEY });
             }
-            if (matches!(storage[key], Entry::Used { .. })) {
+            if matches!(storage[key], Entry::Used { .. }) {
                 return Err(serde::de::Error::duplicate_field("(numeric)"));
             }
             storage[key] = Entry::Used { contents };

--- a/src/type_system/scheduling.rs
+++ b/src/type_system/scheduling.rs
@@ -70,7 +70,7 @@ impl NodeType
 
 fn check_slot_type(program : & ir::Program, type_id : ir::TypeId, node_type : & NodeType)
 {
-	match & program.types[& type_id]
+	match & program.types[type_id]
 	{
 		ir::Type::Slot { storage_type : storage_type_2, queue_stage : queue_stage_2, queue_place : queue_place_2 } =>
 		{
@@ -124,7 +124,7 @@ impl<'program> FuncletChecker<'program>
 	pub fn new(program : & 'program ir::Program, scheduling_funclet : & 'program ir::Funclet, scheduling_funclet_extra : & 'program ir::SchedulingFuncletExtra) -> Self
 	{
 		assert_eq!(scheduling_funclet.kind, ir::FuncletKind::ScheduleExplicit);
-		let value_funclet = & program.funclets[& scheduling_funclet_extra.value_funclet_id];
+		let value_funclet = & program.funclets[scheduling_funclet_extra.value_funclet_id];
 		assert_eq!(value_funclet.kind, ir::FuncletKind::Value);
 		let mut state = Self
 		{
@@ -161,7 +161,7 @@ impl<'program> FuncletChecker<'program>
 			};
 			assert!(is_valid);
 
-			let node_type = match & self.program.types[input_type_id]
+			let node_type = match & self.program.types[*input_type_id]
 			{
 				ir::Type::Slot { storage_type, queue_stage, queue_place } =>
 				{
@@ -206,7 +206,7 @@ impl<'program> FuncletChecker<'program>
 		{
 			let (value_tag, timeline_tag, spatial_tag) = self.get_funclet_output_tags(self.scheduling_funclet, self.scheduling_funclet_extra, output_index);
 
-			match & self.program.types[output_type]
+			match & self.program.types[*output_type]
 			{
 				ir::Type::Slot{queue_place, ..} =>
 				{
@@ -236,7 +236,7 @@ impl<'program> FuncletChecker<'program>
 	fn get_funclet_input_tags(&self, funclet : & ir::Funclet, funclet_extra : & ir::SchedulingFuncletExtra, input_index : usize) -> (ir::ValueTag, ir::TimelineTag, ir::SpatialTag)
 	{
 		let type_id = funclet.input_types[input_index];
-		match & self.program.types[& type_id]
+		match & self.program.types[type_id]
 		{
 			ir::Type::Slot{..} =>
 			{
@@ -261,7 +261,7 @@ impl<'program> FuncletChecker<'program>
 	{
 		let type_id = funclet.output_types[output_index];
 		// Doesn't work with joins as arguments
-		match & self.program.types[& type_id]
+		match & self.program.types[type_id]
 		{
 			ir::Type::Slot{..} =>
 			{
@@ -425,7 +425,7 @@ impl<'program> FuncletChecker<'program>
 			{
 				assert_eq!(self.scheduling_funclet_extra.value_funclet_id, operation.funclet_id);
 
-				let encoded_funclet = & self.program.funclets[& operation.funclet_id];
+				let encoded_funclet = & self.program.funclets[operation.funclet_id];
 				let encoded_node = & encoded_funclet.nodes[operation.node_id];
 
 				match encoded_node
@@ -464,7 +464,7 @@ impl<'program> FuncletChecker<'program>
 					ir::Node::CallExternalCpu { external_function_id, arguments } =>
 					{
 						assert_eq!(* place, ir::Place::Local);
-						let function = & self.program.native_interface.external_cpu_functions[external_function_id];
+						let function = & self.program.native_interface.external_cpu_functions[*external_function_id];
 						// To do: Input checks 
 
 						for (input_index, input_node_id) in arguments.iter().enumerate()
@@ -482,7 +482,7 @@ impl<'program> FuncletChecker<'program>
 					ir::Node::CallExternalGpuCompute { external_function_id, arguments, dimensions } =>
 					{
 						assert_eq!(* place, ir::Place::Gpu);
-						let function = & self.program.native_interface.external_gpu_functions[external_function_id];
+						let function = & self.program.native_interface.external_gpu_functions[*external_function_id];
 		
 						assert_eq!(inputs.len(), dimensions.len() + arguments.len());
 						assert_eq!(outputs.len(), function.output_types.len());
@@ -786,7 +786,7 @@ impl<'program> FuncletChecker<'program>
 
 	fn handle_join(&mut self, join_funclet_id : ir::FuncletId, captures : &[ir::NodeId], continuation_join_node_id : ir::NodeId, join_kind : JoinKind)
 	{
-		let join_funclet = & self.program.funclets[& join_funclet_id];
+		let join_funclet = & self.program.funclets[join_funclet_id];
 		let join_funclet_extra = & self.program.scheduling_funclet_extras[& join_funclet_id];
 		let continuation_join_point = & self.node_join_points[& continuation_join_node_id];
 		
@@ -951,11 +951,11 @@ impl<'program> FuncletChecker<'program>
 
 				assert_eq!(value_operation.funclet_id, self.value_funclet_id);
 
-				let callee_funclet = & self.program.funclets[& callee_scheduling_funclet_id];
+				let callee_funclet = & self.program.funclets[callee_scheduling_funclet_id];
 				assert_eq!(callee_funclet.kind, ir::FuncletKind::ScheduleExplicit);
 				let callee_funclet_scheduling_extra = & self.program.scheduling_funclet_extras[& callee_scheduling_funclet_id];
 				let callee_value_funclet_id = callee_funclet_scheduling_extra.value_funclet_id;
-				let callee_value_funclet = & self.program.funclets[& callee_value_funclet_id];
+				let callee_value_funclet = & self.program.funclets[callee_value_funclet_id];
 				assert_eq!(callee_value_funclet.kind, ir::FuncletKind::Value);
 
 				check_timeline_tag_compatibility_interior(& self.program, self.current_timeline_tag, callee_funclet_scheduling_extra.in_timeline_tag);
@@ -1013,12 +1013,12 @@ impl<'program> FuncletChecker<'program>
 				assert_eq!(callee_funclet_ids.len(), 2);
 				let true_funclet_id = callee_funclet_ids[0];
 				let false_funclet_id = callee_funclet_ids[1];
-				let true_funclet = & self.program.funclets[& true_funclet_id];
-				let false_funclet = & self.program.funclets[& false_funclet_id];
+				let true_funclet = & self.program.funclets[true_funclet_id];
+				let false_funclet = & self.program.funclets[false_funclet_id];
 				let true_funclet_extra = & self.program.scheduling_funclet_extras[& true_funclet_id];
 				let false_funclet_extra = & self.program.scheduling_funclet_extras[& false_funclet_id];
 
-				let current_value_funclet = & self.program.funclets[& value_operation.funclet_id];
+				let current_value_funclet = & self.program.funclets[value_operation.funclet_id];
 				assert_eq!(current_value_funclet.kind, ir::FuncletKind::Value);
 
 				let condition_value_tag = self.scalar_node_value_tags[condition_slot_node_id];
@@ -1089,12 +1089,12 @@ impl<'program> FuncletChecker<'program>
 
 				let true_funclet_id = success_funclet_id;
 				let false_funclet_id = failure_funclet_id;
-				let true_funclet = & self.program.funclets[& true_funclet_id];
-				let false_funclet = & self.program.funclets[& false_funclet_id];
+				let true_funclet = & self.program.funclets[*true_funclet_id];
+				let false_funclet = & self.program.funclets[*false_funclet_id];
 				let true_funclet_extra = & self.program.scheduling_funclet_extras[& true_funclet_id];
 				let false_funclet_extra = & self.program.scheduling_funclet_extras[& false_funclet_id];
 
-				let current_value_funclet = & self.program.funclets[& self.value_funclet_id];
+				let current_value_funclet = & self.program.funclets[self.value_funclet_id];
 				assert_eq!(current_value_funclet.kind, ir::FuncletKind::Value);
 
 				let buffer_spatial_tag = self.scalar_node_spatial_tags[buffer_node_id];
@@ -1145,7 +1145,7 @@ impl<'program> FuncletChecker<'program>
 					}
 
 					let destination_type_id = true_funclet.input_types[input_index];
-					match & self.program.types[& destination_type_id]
+					match & self.program.types[destination_type_id]
 					{
 						ir::Type::Slot{queue_stage, queue_place, storage_type, ..} =>
 						{
@@ -1153,7 +1153,7 @@ impl<'program> FuncletChecker<'program>
 							assert_eq!(* queue_stage, ir::ResourceQueueStage::Bound);
 							if allocation_size_node_id_opt.is_some()
 							{
-								match & self.program.native_interface.types[& storage_type.0]
+								match & self.program.native_interface.types[storage_type.0]
 								{
 									ir::ffi::Type::ErasedLengthArray{element_type} => (),
 									_ => panic!("Invalid storage type for dynamic allocation (native interface type {})", storage_type.0)
@@ -1161,7 +1161,7 @@ impl<'program> FuncletChecker<'program>
 							}
 							else
 							{
-								match & self.program.native_interface.types[& storage_type.0]
+								match & self.program.native_interface.types[storage_type.0]
 								{
 									ir::ffi::Type::ErasedLengthArray{element_type} => panic!("Invalid storage type for dynamic allocation (native interface type {})", storage_type.0),
 									_ => ()

--- a/src/type_system/spatial_tag.rs
+++ b/src/type_system/spatial_tag.rs
@@ -21,7 +21,7 @@ pub fn check_spatial_tag_compatibility_interior(program : & ir::Program, source_
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let destination_funclet = & program.funclets[& funclet_id];
+			let destination_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_funclet.kind, ir::FuncletKind::Spatial);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_funclet.nodes[remote_node_id.node_id]
@@ -37,7 +37,7 @@ pub fn check_spatial_tag_compatibility_interior(program : & ir::Program, source_
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let destination_funclet = & program.funclets[& funclet_id];
+			let destination_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_funclet.kind, ir::FuncletKind::Spatial);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_funclet.nodes[remote_node_id.node_id]
@@ -57,7 +57,7 @@ pub fn check_spatial_tag_compatibility_interior(program : & ir::Program, source_
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let source_funclet = & program.funclets[& funclet_id];
+			let source_funclet = & program.funclets[funclet_id];
 			assert_eq!(source_funclet.kind, ir::FuncletKind::Spatial);
 
 			match & source_funclet.tail_edge

--- a/src/type_system/timeline_tag.rs
+++ b/src/type_system/timeline_tag.rs
@@ -45,7 +45,7 @@ pub fn check_timeline_tag_compatibility_interior(program : & ir::Program, source
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let destination_timeline_funclet = & program.funclets[& funclet_id];
+			let destination_timeline_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_timeline_funclet.nodes[remote_node_id.node_id]
@@ -61,7 +61,7 @@ pub fn check_timeline_tag_compatibility_interior(program : & ir::Program, source
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let destination_timeline_funclet = & program.funclets[& funclet_id];
+			let destination_timeline_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_timeline_funclet.nodes[remote_node_id.node_id]
@@ -81,7 +81,7 @@ pub fn check_timeline_tag_compatibility_interior(program : & ir::Program, source
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let source_timeline_funclet = & program.funclets[& funclet_id];
+			let source_timeline_funclet = & program.funclets[funclet_id];
 			assert_eq!(source_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 			match & source_timeline_funclet.tail_edge
@@ -104,7 +104,7 @@ pub fn check_timeline_tag_compatibility_interior(program : & ir::Program, source
 pub fn check_next_timeline_tag_on_submit(program : & ir::Program, timeline_event : ir::RemoteNodeId, current_timeline_tag : ir::TimelineTag) -> ir::TimelineTag
 {
 	// To do: have timeline tag for both gpu and local
-	let destination_timeline_funclet = & program.funclets[& timeline_event.funclet_id];
+	let destination_timeline_funclet = & program.funclets[timeline_event.funclet_id];
 	assert_eq!(destination_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 	let (here_place, there_place, local_past) = match & destination_timeline_funclet.nodes[timeline_event.node_id]
@@ -122,7 +122,7 @@ pub fn check_next_timeline_tag_on_submit(program : & ir::Program, timeline_event
 		{
 			assert_eq!(timeline_event.funclet_id, funclet_id);
 
-			let destination_timeline_funclet = & program.funclets[& funclet_id];
+			let destination_timeline_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_timeline_funclet.nodes[local_past]
@@ -148,7 +148,7 @@ pub fn check_next_timeline_tag_on_submit(program : & ir::Program, timeline_event
 pub fn check_next_timeline_tag_on_sync(program : & ir::Program, timeline_event : ir::RemoteNodeId, current_timeline_tag : ir::TimelineTag) -> ir::TimelineTag
 {
 	// To do: have timeline tag for both gpu and local
-	let destination_timeline_funclet = & program.funclets[& timeline_event.funclet_id];
+	let destination_timeline_funclet = & program.funclets[timeline_event.funclet_id];
 	assert_eq!(destination_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 	let (here_place, there_place, local_past, remote_local_past) = match & destination_timeline_funclet.nodes[timeline_event.node_id]
@@ -166,7 +166,7 @@ pub fn check_next_timeline_tag_on_sync(program : & ir::Program, timeline_event :
 		{
 			assert_eq!(timeline_event.funclet_id, funclet_id);
 
-			let destination_timeline_funclet = & program.funclets[& funclet_id];
+			let destination_timeline_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_timeline_funclet.kind, ir::FuncletKind::Timeline);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_timeline_funclet.nodes[local_past]

--- a/src/type_system/value_tag.rs
+++ b/src/type_system/value_tag.rs
@@ -20,7 +20,7 @@ pub fn check_value_tag_compatibility_enter(program : & ir::Program, call_operati
 		(ir::ValueTag::Operation{remote_node_id}, ir::ValueTag::Input{funclet_id, index}) =>
 		{
 			assert_eq!(call_operation.funclet_id, remote_node_id.funclet_id);
-			let caller_value_funclet = & program.funclets[& call_operation.funclet_id];
+			let caller_value_funclet = & program.funclets[call_operation.funclet_id];
 			if let ir::Node::CallValueFunction{function_id, arguments} = & caller_value_funclet.nodes[call_operation.node_id]
 			{
 				assert_eq!(arguments[index], remote_node_id.node_id);
@@ -45,7 +45,7 @@ pub fn check_value_tag_compatibility_exit(program : & ir::Program, callee_funcle
 			assert_eq!(remote_node_id.funclet_id, continuation_value_operation.funclet_id);
 			assert_eq!(funclet_id, callee_funclet_id);
 
-			let node = & program.funclets[& remote_node_id.funclet_id].nodes[remote_node_id.node_id];
+			let node = & program.funclets[remote_node_id.funclet_id].nodes[remote_node_id.node_id];
 			if let ir::Node::ExtractResult{node_id : call_node_id, index} = node
 			{
 				assert_eq!(* index, output_index);
@@ -63,7 +63,7 @@ pub fn check_value_tag_compatibility_exit(program : & ir::Program, callee_funcle
 pub fn check_value_tag_compatibility_interior_branch(program : & ir::Program, value_operation : ir::RemoteNodeId, condition_value_tag : ir::ValueTag, source_value_tags : &[ir::ValueTag], destination_value_tag : ir::ValueTag)
 {
 	assert_eq!(source_value_tags.len(), 2);
-	let current_value_funclet = & program.funclets[& value_operation.funclet_id];
+	let current_value_funclet = & program.funclets[value_operation.funclet_id];
 	assert_eq!(current_value_funclet.kind, ir::FuncletKind::Value);
 
 	let branch_node_ids = if let ir::Node::Select{condition, true_case, false_case} = & current_value_funclet.nodes[value_operation.node_id]
@@ -105,7 +105,7 @@ pub fn check_value_tag_compatibility_interior(program : & ir::Program, source_va
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let destination_value_funclet = & program.funclets[& funclet_id];
+			let destination_value_funclet = & program.funclets[funclet_id];
 			assert_eq!(destination_value_funclet.kind, ir::FuncletKind::Value);
 
 			if let ir::Node::Phi{index : phi_index} = & destination_value_funclet.nodes[remote_node_id.node_id]
@@ -125,7 +125,7 @@ pub fn check_value_tag_compatibility_interior(program : & ir::Program, source_va
 		{
 			assert_eq!(remote_node_id.funclet_id, funclet_id);
 
-			let source_value_funclet = & program.funclets[& funclet_id];
+			let source_value_funclet = & program.funclets[funclet_id];
 			assert_eq!(source_value_funclet.kind, ir::FuncletKind::Value);
 
 			match & source_value_funclet.tail_edge


### PR DESCRIPTION
This makes Arena more efficient*, enforces a consistent iteration/serialization order, and also has some other extra functionality added. We should probably rename it as well -- any suggestions?

I'm opening this as a draft because my testing procedure was literally "run cargo test on caiman-test".

*unless deserializing sparsely-populated Arenas