### PR TITLE
Bunch of fixes/changes related to CPU allocation

### DIFF
--- a/caiman-rt/src/lib.rs
+++ b/caiman-rt/src/lib.rs
@@ -181,6 +181,25 @@ impl<'buffer> CpuBufferAllocator<'buffer>
 }
 
 #[derive(Debug)]
+// A slot holding a pointer to gpu-resident data of type T
+pub struct CpuBufferRef<'buffer, T : Sized>
+{
+	pub buffer : & 'buffer std::mem::MaybeUninit<T>,
+}
+
+impl<'buffer, T : Sized> CpuBufferRef<'buffer, T>
+{
+	pub fn new(buffer : & 'buffer std::mem::MaybeUninit<T>)
+		-> Self
+	{
+		Self {
+			buffer,
+		}
+	}
+
+}
+
+#[derive(Debug)]
 pub struct JoinStack<'buffer>
 {
 	bytes : & 'buffer mut [u8],

--- a/caiman-test/programs/example.cair
+++ b/caiman-test/programs/example.cair
@@ -5,7 +5,10 @@ version 0.0.1
 types [
     f32,f64,u8,u16,u32,u64,usize,i8,i16,i32,i64,array<i32, 2>,erased_length_array<u32>,
     tuple<f32, u8>,const_ref<u64>,mut_ref<const_ref<u64>>,const_slice<array<i32, 2>>,mut_slice<i32>,
-    gpu_buffer_ref<i32>,gpu_buffer_slice<i32>,gpu_buffer_allocator,
+    gpu_buffer_ref<i32>,gpu_buffer_slice<i32>,gpu_buffer_allocator,cpu_buffer_allocator,cpu_buffer_ref<i64>,
+    native_value $native_i64 {
+        type : i64,
+    },
     slot $slot0 {
         type : i64,
         stage : ready,
@@ -16,7 +19,7 @@ types [
     },
     buffer $buffer0 {
         place : gpu,
-        static_layout_opt : { // unnamed :hmmmm:
+        static_layout_opt : {
             alignment_bits : 4,
             byte_size : 8
         },

--- a/caiman-test/scheduling/cpu_allocate_baseline.cair
+++ b/caiman-test/scheduling/cpu_allocate_baseline.cair
@@ -1,0 +1,81 @@
+version 0.0.1
+
+types [
+    i64,
+    native_value $native_i64 {
+        type : i64
+    },
+    slot $slot_local {
+        type : i64,
+        stage : ready,
+        place : local,
+    },
+    slot $slot_cpu {
+        type : i64,
+        stage : ready,
+        place : cpu,
+    },
+    buffer $buffer_cpu {
+        place : cpu,
+        static_layout_opt : {
+            alignment_bits : 0,
+            byte_size : 4096
+        },
+    },
+    event $event0 {
+        place : local
+    },
+    space_buffer $buffer_space {},
+]
+
+external_cpu i64 @op(i64);
+
+value i64 @foo(%i : i64) {
+//    %x = constant 2i64;
+    %y = call @op(%i);
+    %z = extract %y 0;
+    return %z;
+}
+
+timeline $event0 @time(%e : $event0) {
+    %sub1 = submission-local->cpu %e;
+    %sync1 = sync-local->cpu %sub1 %sub1;
+    return %sync1;
+}
+
+schedule $slot_cpu @bar(%s : $slot_local, %buff : $buffer_cpu) {
+//    %0 = alloc-temporary-local-i64 @foo.%x;
+//    %1 = encode-do-local @foo.%x() -> %0;
+    %2 = alloc-cpu-i64 %buff @foo.%i;
+    %3 = encode-copy-cpu %s %2;
+    %4 = alloc-cpu-i64 %buff @foo.%z;
+    %5 = encode-do-cpu @foo.%y(%2) -> %4;
+    %6 = submit-cpu @time.%sub1;
+    %7 = encode-fence-cpu @time.%sub1;
+    %8 = sync-fence-cpu %7 @time.%sync1;
+    return %4;
+}
+
+spatial $buffer_space @space(%bs : $buffer_space) {
+    return %bs;
+}
+
+extras {
+    @bar {
+        value : @foo,
+        input_slots : {
+            %s : slot_info(value_tag input @foo.%i)
+        },
+        output_slots : {
+            %s : slot_info(value_tag output @foo.%i, spatial_tag output @space.%bs)
+        },
+        input_fences : {},
+        output_fences : {},
+        input_buffers : {%buff : buffer_info(spatial_tag input @space.%bs)},
+        output_buffers : {},
+        in_timeline_tag : timeline_tag input @time.%e,
+        out_timeline_tag : timeline_tag output @time.%e,
+    },
+}
+
+pipeline "main" = @bar;

--- a/caiman-test/scheduling/gpu_external_baseline.cair
+++ b/caiman-test/scheduling/gpu_external_baseline.cair
@@ -7,11 +7,14 @@ types [
         stage : ready,
         place : local,
     },
-    slot $slot_gpu {
-        type : i64,
-        stage : ready,
+    slot $buffer_gpu {
+        static_layout_opt : {
+            alignment_bits : 0,
+            byte_size : 4096
+        },
         place : gpu,
     },
+
     event $event0 {
         place : local
     },
@@ -42,7 +45,7 @@ schedule $slot0 @foo_main(%blob : $slot0, %gpu_blob : $slot_gpu) {
     %0 = alloc-local-i64 %blob @foo.%x;
     %t0 = encode-do-local @foo.%x() -> %0;
 
-    %1 = alloc-gpu-i64 @foo.%gpu_blob %y;
+    %1 = alloc-gpu-i64 %gpu_blob @foo.%gpu_blob;
     %t1 = encode-do-gpu @foo.%ty(%0) -> %1;
     return %1;
 }

--- a/src/assembly/ast_to_ir.rs
+++ b/src/assembly/ast_to_ir.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{assembly_ast, frontend, ir};
 use crate::ir::ffi;
 use crate::assembly::{context, parser};
-use crate::assembly_ast::{FFIType, TypeKind};
+use crate::assembly_ast::FFIType;
 use crate::assembly::context::{Context, FuncletLocation};
 
 // for reading GPU stuff
@@ -58,7 +58,10 @@ fn ffi_to_ffi(value : FFIType, context : &mut Context) -> ffi::Type {
             ffi::Type::GpuBufferRef { element_type: type_id(element_type, context) },
         FFIType::GpuBufferSlice(element_type) =>
             ffi::Type::GpuBufferSlice { element_type: type_id(element_type, context) },
-        FFIType::GpuBufferAllocator => ffi::Type::GpuBufferAllocator
+        FFIType::GpuBufferAllocator => ffi::Type::GpuBufferAllocator,
+        FFIType::CpuBufferAllocator => ffi::Type::CpuBufferAllocator,
+        FFIType::CpuBufferRef(element_type) =>
+            ffi::Type::CpuBufferRef { element_type: type_id(element_type, context) },
     }
 }
 
@@ -182,7 +185,7 @@ fn value_core_tag(v : assembly_ast::TagCore, context : &mut Context) -> ir::Valu
             funclet_id : *context.local_funclet_id(r.funclet_id.clone()),
             index: *context.remote_node_id(r.funclet_id.clone(), r.node_id.clone()),
         },
-        assembly_ast::TagCore::Output(r) => ir::ValueTag::Input {
+        assembly_ast::TagCore::Output(r) => ir::ValueTag::Output {
             funclet_id : *context.local_funclet_id(r.funclet_id.clone()),
             index: *context.remote_node_id(r.funclet_id.clone(), r.node_id.clone()),
         },
@@ -216,7 +219,7 @@ fn spatial_core_tag(v : assembly_ast::TagCore, context : &mut Context) -> ir::Sp
             funclet_id : *context.local_funclet_id(r.funclet_id.clone()),
             index: *context.remote_node_id(r.funclet_id.clone(), r.node_id.clone()),
         },
-        assembly_ast::TagCore::Output(r) => ir::SpatialTag::Input {
+        assembly_ast::TagCore::Output(r) => ir::SpatialTag::Output {
             funclet_id : *context.local_funclet_id(r.funclet_id.clone()),
             index: *context.remote_node_id(r.funclet_id.clone(), r.node_id.clone()),
         },
@@ -478,9 +481,20 @@ fn ir_types(types : &Vec<assembly_ast::TypeDecl>, context : &mut Context) -> Sta
     for type_decl in types {
         let new_type = match type_decl {
             assembly_ast::TypeDecl::Local(typ) => {
-                match typ.type_kind
+                Some(match typ.type_kind
                 { // only supported custom types atm
-                    TypeKind::Slot => {
+                    assembly_ast::TypeKind::NativeValue => {
+                        let type_found = typ.data.get(&as_key("type")).unwrap();
+                        let storage_type = match value_type(type_found, context) {
+                            context::Location::Local(t) => panic!(format!(
+                                "Expected ffi type in native value, got {:?}", type_found)),
+                            context::Location::FFI(i) => ffi::TypeId(i)
+                        };
+                        ir::Type::NativeValue {
+                            storage_type,
+                        }
+                    }
+                    assembly_ast::TypeKind::Slot => {
                         ir::Type::Slot {
                             storage_type: ffi::TypeId(value_type(
                                 typ.data.get(&as_key("type")).unwrap(), context).unpack()),
@@ -488,13 +502,13 @@ fn ir_types(types : &Vec<assembly_ast::TypeDecl>, context : &mut Context) -> Sta
                             queue_place: value_place(typ.data.get(&as_key("place")).unwrap(), context),
                         }
                     }
-                    TypeKind::Fence => {
+                    assembly_ast::TypeKind::Fence => {
                         ir::Type::Fence {
                             queue_place: value_place(typ.data.get(&as_key("place")).unwrap(), context),
                         }
                     }
-                    TypeKind::Buffer => {
-                        let static_layout_dict = typ.data.get(&as_key("static_layout_opt"));
+                    assembly_ast::TypeKind::Buffer => {
+                        let static_layout_dict = typ.data.get(&as_key("static_layout_opt")).unwrap();
                         fn static_layout_map(d : assembly_ast::UncheckedDict, context : &mut Context)
                         -> ir::StaticBufferLayout {
                             let alignment_bits = value_num(d.get(
@@ -503,31 +517,35 @@ fn ir_types(types : &Vec<assembly_ast::TypeDecl>, context : &mut Context) -> Sta
                                 &as_key("byte_size")).unwrap(), context);
                             ir::StaticBufferLayout { alignment_bits, byte_size }
                         }
-                        let static_layout_opt = static_layout_dict.map(|d|
-                            static_layout_map(as_dict(d.clone()), context));
+                        let static_layout_opt = match static_layout_dict {
+                            assembly_ast::DictValue::Raw(assembly_ast::Value::None) => {None},
+                            assembly_ast::DictValue::Dict(dv) => {
+                                Some(static_layout_map(dv.clone(), context))
+                            },
+                            _ => panic!(format!("Unsupported result for {:?}", static_layout_dict))
+                        };
                         ir::Type::Buffer {
                             storage_place: value_place(typ.data.get(&as_key("place")).unwrap(), context),
                             static_layout_opt,
                         }
                     }
-                    TypeKind::Event => {
+                    assembly_ast::TypeKind::Event => {
                         ir::Type::Event {
                         place: value_place(
                             typ.data.get(&as_key("place")).unwrap(), context),
                         }
                     }
-                    TypeKind::BufferSpace => {
+                    assembly_ast::TypeKind::BufferSpace => {
                         ir::Type::BufferSpace
                     }
-                }
+                })
             }
-            assembly_ast::TypeDecl::FFI(name) => {
-                ir::Type::NativeValue {
-                    storage_type: ffi::TypeId(*context.ffi_type_id(name))
-                }
-            }
+            assembly_ast::TypeDecl::FFI(name) => {None}
         };
-        result.add(new_type);
+        match new_type {
+            Some(t) => {result.add(t);},
+            None => {}
+        }
     }
     result
 }
@@ -784,7 +802,8 @@ fn ir_funclet(funclet : &assembly_ast::Funclet, context : &mut Context) -> ir::F
             None => {},
             Some(s) => { nodes.push(ir::Node::Phi { index } ) }
         };
-        input_types.push(*context.loc_type_id(input_type.1.clone()))
+        input_types.push(*context.loc_type_id(input_type.1.clone()));
+        index += 1;
     }
 
     output_types.push(*context.loc_type_id(funclet.header.ret.clone()));

--- a/src/assembly/caimanir.pest
+++ b/src/assembly/caimanir.pest
@@ -7,6 +7,7 @@ sep = _{ WHITESPACE+ }
 //   baseline
 id = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 n = @{ ASCII_DIGIT+ }
+none = { "none" }
 str_single = @{ "'" ~ (!"'" ~ !NEWLINE ~ ANY)* ~ "'" }
 str_double = @{ "\"" ~ (!"\"" ~ !NEWLINE ~ ANY)* ~ "\"" }
 str = @{ str_single | str_double }
@@ -21,12 +22,13 @@ funclet_loc_sep = ${ funclet_loc ~ sep }
 
 //    ffi_types
 ffi_type_base = { "i32" | "f32" | "f64" | "u8" | "u16" | "u32" | "u64" | "usize" | "i8" |
-                      "i16" | "i32" | "i64" | "gpu_buffer_allocator" }
+                      "i16" | "i32" | "i64" | "gpu_buffer_allocator" | "cpu_buffer_allocator" }
 ffi_ref_parameter = { "<" ~ ffi_type ~ ">"}
 ffi_array_parameters = { "<" ~ ffi_type ~ "," ~ n ~ ">" }
 ffi_tuple_parameters = { "<" ~ ffi_type ~ ("," ~ ffi_type)* ~ ">" } // must have at least one field
 ffi_parameterized_ref_name = { "erased_length_array" | "const_ref" |
-    "mut_ref" | "const_slice" | "mut_slice" | "gpu_buffer_ref" | "gpu_buffer_slice" }
+    "mut_ref" | "const_slice" | "mut_slice" | "gpu_buffer_ref" | "gpu_buffer_slice" |
+    "cpu_buffer_ref" }
 
 ffi_parameterized_array = { "array" ~ ffi_array_parameters } // kinda lazy tbh, but annoying to make nicer
 ffi_parameterized_ref = { ffi_parameterized_ref_name ~ ffi_ref_parameter }
@@ -45,8 +47,7 @@ constant = ${ n ~ ffi_type } // maybe needs reworking eventually :thinking:
 
 //   tags
 tag_core_op = { "operation" | "input" | "output" }
-tag_none = { "none" }
-tag_core = ${ tag_none | tag_core_op ~ sep ~ funclet_loc }
+tag_core = ${ none | tag_core_op ~ sep ~ funclet_loc }
 tag_halt = ${ "halt" ~ sep ~ var_name }
 value_tag_op = { "function_input" | "function_output" }
 value_tag_loc = ${ value_tag_op ~ sep ~ funclet_loc }
@@ -66,7 +67,8 @@ slot_info = { "slot_info" ~ "(" ~ (tag ~ ("," ~ tag)*)? ~ ")" }
 fence_info = { "fence_info" ~ "(" ~ timeline_tag? ~ ")" }
 buffer_info = { "buffer_info" ~ "(" ~ spatial_tag? ~ ")" }
 dict_key = { id | var_name }
-value = { var_name | n | funclet_loc | fn_name | typ | place | stage | tag | slot_info | fence_info | buffer_info | str }
+value = { var_name | n | funclet_loc | fn_name | typ | place | none |
+    stage | tag | slot_info | fence_info | buffer_info | str }
 list_values = { dict_value ~ ("," ~ dict_value)* ~ ","? }
 list = { "[" ~ list_values? ~ "]" }
 dict_value = { value | list | unchecked_dict }
@@ -81,7 +83,7 @@ version = ${ version_keyword ~ n ~ "." ~ n ~ "." ~ n }
 
 // Types
 types = { "types" ~ "[" ~ type_def? ~ ("," ~ type_def)* ~ ","? ~ "]" }
-ir_type_decl_key = { "slot" | "fence" | "buffer" | "event" | "space_buffer" }
+ir_type_decl_key = { "native_value" | "slot" | "fence" | "buffer" | "event" | "space_buffer" }
 ir_type_decl_key_sep = ${ ir_type_decl_key ~ sep }
 ir_type_decl = { ir_type_decl_key_sep ~ type_name ~ unchecked_dict }
 ffi_type_decl = { ffi_type }
@@ -146,8 +148,7 @@ tail_fn_box = { "[" ~ tail_fn_nodes? ~ "]" }
 schedule_select_command = { schedule_select_sep ~ funclet_loc ~ var_name ~ tail_fn_box ~ node_box ~ var_name }
 
 dynamic_alloc_sep = ${ "dynamic-alloc" ~ sep }
-tail_none = { "none" }
-tail_option_node = { var_name | tail_none }
+tail_option_node = { var_name | none }
 tail_option_nodes = { tail_option_node ~ ("," ~ tail_option_node)* }
 tail_option_box = { "[" ~ tail_option_nodes? ~ "]" }
 dynamic_alloc_command = { dynamic_alloc_sep ~ var_name ~ node_box ~ tail_option_box ~ fn_name ~ fn_name ~ var_name }

--- a/src/assembly/context.rs
+++ b/src/assembly/context.rs
@@ -6,7 +6,8 @@ use crate::assembly_ast;
 
 #[derive(Debug, Clone)]
 struct TypeIndices {
-    type_index : usize
+    ffi_type_index : usize,
+    local_type_index : usize
 }
 
 #[derive(Debug, Clone)]
@@ -74,7 +75,8 @@ impl Context {
 
     pub fn initiate_type_indices(&mut self) {
         self.indices = Indices::TypeIndices(TypeIndices {
-            type_index : 0
+            ffi_type_index : 0,
+            local_type_index : 0,
         })
     }
 
@@ -108,9 +110,9 @@ impl Context {
             Indices::TypeIndices(t) => t,
             _ => panic!(format!("Invalid access attempt {:?}", name))
         };
-        let index = indices.type_index;
+        let index = indices.ffi_type_index;
         self.ffi_type_map.insert(name, index);
-        indices.type_index += 1;
+        indices.ffi_type_index += 1;
     }
 
     pub fn add_local_type(&mut self, name : String) {
@@ -118,9 +120,9 @@ impl Context {
             Indices::TypeIndices(t) => t,
             _ => panic!(format!("Invalid access attempt {:?}", name))
         };
-        let index = indices.type_index;
+        let index = indices.local_type_index;
         self.local_type_map.insert(name, index);
-        indices.type_index += 1;
+        indices.local_type_index += 1;
     }
 
     pub fn add_cpu_funclet(&mut self, name : String) {

--- a/src/assembly/parser.rs
+++ b/src/assembly/parser.rs
@@ -274,6 +274,10 @@ fn rule_id<'a>() -> RuleApp<'a, assembly_ast::Value> {
     rule_str(Rule::id, read_id)
 }
 
+fn read_none_value(_ : String, _ : &mut Context) -> assembly_ast::Value {
+    assembly_ast::Value::None
+}
+
 fn read_ffi_type_base(s : String, context : &mut Context) -> assembly_ast::FFIType {
     match s.as_str() {
         "f32" => { assembly_ast::FFIType::F32 },
@@ -288,6 +292,7 @@ fn read_ffi_type_base(s : String, context : &mut Context) -> assembly_ast::FFITy
         "i64" => { assembly_ast::FFIType::I64 },
         "usize" => { assembly_ast::FFIType::USize },
         "gpu_buffer_allocator" => { assembly_ast::FFIType::GpuBufferAllocator },
+        "cpu_buffer_allocator" => { assembly_ast::FFIType::CpuBufferAllocator },
         _ => panic!("Unknown type name {}", s)
     }
 }
@@ -323,6 +328,7 @@ fn read_ffi_parameterized_ref_name(s : String, context : &mut Context)
         "mut_slice" => box_up(&assembly_ast::FFIType::MutSlice),
         "gpu_buffer_ref" => box_up(&assembly_ast::FFIType::GpuBufferRef),
         "gpu_buffer_slice" => box_up(&assembly_ast::FFIType::GpuBufferSlice),
+        "cpu_buffer_ref" => box_up(&assembly_ast::FFIType::CpuBufferRef),
         _ => panic!("Unknown type name {}", s)
     }
 }
@@ -457,9 +463,9 @@ fn read_tag_core(pairs : &mut Pairs<Rule>, context : &mut Context) -> assembly_a
     let pair = pairs.peek().unwrap();
     let rule = pair.as_rule();
     match rule {
-        Rule::tag_none => assembly_ast::TagCore::None,
+        Rule::none => assembly_ast::TagCore::None,
         Rule::tag_core_op => read_tag_core_op(pairs, context),
-        _ => panic!(unexpected_rule_raw(vec![Rule::tag_none, Rule::tag_core_op], rule))
+        _ => panic!(unexpected_rule_raw(vec![Rule::none, Rule::tag_core_op], rule))
     }
 }
 
@@ -577,9 +583,9 @@ fn read_buffer_info(pairs : &mut Pairs<Rule>, context : &mut Context) -> assembl
 }
 
 fn read_value(pairs : &mut Pairs<Rule>, context : &mut Context) -> assembly_ast::Value {
-    // funclet_loc | var_name | fn_name | typ | place | stage | tag
     let mut rules = Vec::new();
 
+    rules.push(rule_str(Rule::none, read_none_value));
     let rule = compose_str(read_n, assembly_ast::Value::Num);
     rules.push(rule_str_boxed(Rule::n, rule));
     let rule = compose_pair(read_fn_name, assembly_ast::Value::VarName);
@@ -683,6 +689,7 @@ fn read_version(pairs : &mut Pairs<Rule>, context : &mut Context) -> assembly_as
 
 fn read_ir_type_decl_key(s : String, _ : &mut Context) -> assembly_ast::TypeKind {
     match s.as_str() {
+        "native_value" => assembly_ast::TypeKind::NativeValue,
         "slot" => assembly_ast::TypeKind::Slot,
         "fence" => assembly_ast::TypeKind::Fence,
         "buffer" => assembly_ast::TypeKind::Buffer,
@@ -958,7 +965,7 @@ fn rule_schedule_select_command<'a>() -> RuleApp<'a, assembly_ast::TailEdge> {
     rule_pair(Rule::schedule_select_command, read_schedule_select_command)
 }
 
-fn read_tail_none(s : String, context : &mut Context) -> Option<String> {
+fn read_tail_none(_ : String, _ : &mut Context) -> Option<String> {
     None
 }
 
@@ -966,7 +973,7 @@ fn read_tail_option_node(pairs : &mut Pairs<Rule>, context : &mut Context) -> Op
     let mut rules = Vec::new();
     let apply_some = compose_pair(read_var_name, Some);
     rules.push(rule_pair_boxed(Rule::var_name, apply_some));
-    rules.push(rule_str(Rule::tail_none, read_tail_none));
+    rules.push(rule_str(Rule::none, read_tail_none));
     expect_vec(rules, pairs, context)
 }
 

--- a/src/assembly_ast.rs
+++ b/src/assembly_ast.rs
@@ -43,6 +43,8 @@ pub enum FFIType
 	GpuBufferRef ( Box<FFIType> ),
 	GpuBufferSlice ( Box<FFIType> ),
 	GpuBufferAllocator,
+	CpuBufferAllocator,
+	CpuBufferRef ( Box<FFIType> ),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
@@ -204,6 +206,7 @@ pub enum Tag {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Value {
+	None,
 	ID(String),
     FunctionLoc(RemoteNodeId),
     VarName(String),
@@ -244,7 +247,7 @@ pub struct Funclet {
 
 #[derive(Debug)]
 pub enum TypeKind {
-	Slot, Fence, Buffer, Event, BufferSpace
+	NativeValue, Slot, Fence, Buffer, Event, BufferSpace
 }
 
 #[derive(Debug)]

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -53,6 +53,7 @@ fn read_definition(input_string : &str, compile_mode : CompileMode) -> Result<De
 pub fn compile_caiman(input_string : &str, options : CompileOptions) -> Result<String, CompileError>
 {
 	let result = read_definition(input_string, options.compile_mode);
+	dbg!(&result);
 	match result
 	{
 		Err(why) => Err(why),

--- a/src/ir/validation.rs
+++ b/src/ir/validation.rs
@@ -108,7 +108,7 @@ pub fn validate_timeline_funclet(program : & ir::Program, funclet : & ir::Funcle
 			{
 				assert!(* local_past < current_node_id);
 				assert_eq!(* here_place, ir::Place::Local);
-				assert_eq!(* there_place, ir::Place::Gpu);
+				assert_ne!(* there_place, ir::Place::Local);
 				most_recently_synchronized_submissions[* local_past]
 			}
 			ir::Node::SynchronizationEvent{here_place, there_place, local_past, remote_local_past} =>
@@ -118,7 +118,7 @@ pub fn validate_timeline_funclet(program : & ir::Program, funclet : & ir::Funcle
 				// Local is always up to date with respect to itself (everything else is in the past) 
 				assert!(* remote_local_past <= * local_past);
 				assert_eq!(* here_place, ir::Place::Local);
-				assert_eq!(* there_place, ir::Place::Gpu);
+				assert_ne!(* there_place, ir::Place::Local);
 
 				let most_recently_sychronized_submission_opt = most_recently_synchronized_submissions[* local_past];
 				if let Some(most_recently_sychronized_submission) = most_recently_sychronized_submission_opt

--- a/src/rust_wgpu_backend/code_generator.rs
+++ b/src/rust_wgpu_backend/code_generator.rs
@@ -1401,6 +1401,7 @@ impl<'program> CodeGenerator<'program>
 			ffi::Type::GpuBufferRef { element_type } => (),
 			ffi::Type::GpuBufferSlice { element_type } => (),
 			ffi::Type::GpuBufferAllocator => (),
+			ffi::Type::CpuBufferAllocator => (),
 			/*ffi::Type::Slot { value_type, queue_stage, queue_place } =>
 			{
 				write!(self.type_code_writer, "pub type type_{} = {};\n", type_id, self.get_type_name(* value_type));

--- a/src/rust_wgpu_backend/ffi.rs
+++ b/src/rust_wgpu_backend/ffi.rs
@@ -41,6 +41,8 @@ pub enum Type
 	GpuBufferRef { element_type : TypeId },
 	GpuBufferSlice { element_type : TypeId },
 	GpuBufferAllocator,
+	CpuBufferAllocator,
+	CpuBufferRef { element_type : TypeId },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/type_system/scheduling.rs
+++ b/src/type_system/scheduling.rs
@@ -463,7 +463,7 @@ impl<'program> FuncletChecker<'program>
 					}
 					ir::Node::CallExternalCpu { external_function_id, arguments } =>
 					{
-						assert_eq!(* place, ir::Place::Local);
+						assert_ne!(* place, ir::Place::Gpu);
 						let function = & self.program.native_interface.external_cpu_functions[*external_function_id];
 
 						assert_eq!(inputs.len(), arguments.len());
@@ -724,9 +724,12 @@ impl<'program> FuncletChecker<'program>
 			ir::Node::StaticAllocFromStaticBuffer{buffer : buffer_node_id, place, storage_type, operation} =>
 			{
 				// Temporary restriction
-				assert_eq!(* place, ir::Place::Gpu);
+				match *place {
+					ir::Place::Local => panic!("Unimplemented allocating locally"),
+					_ => {}
+				}
 				let buffer_spatial_tag = self.scalar_node_spatial_tags[buffer_node_id];
-				assert!(buffer_spatial_tag != ir::SpatialTag::None);
+				assert_ne!(buffer_spatial_tag, ir::SpatialTag::None);
 				
 				if let Some(NodeType::Buffer(Buffer{storage_place, static_layout_opt : Some(static_layout)})) = self.node_types.get_mut(buffer_node_id)
 				{


### PR DESCRIPTION
This is a work-in-progress attempt to make `StaticAllocFromStaticBuffer` work on the CPU.  Contains a bunch of parser fixes that are probably important for GPU allocation as well.  The actual file that can be tested is caiman-test/scheduling/cpu_allocate_baseline.cair -- this is the code I was trying to make work, though the code itself might have issues as well.

The reason this commit is unfinished is that there seems to be a decent number more steps to implement (I'll file an issue as well), and I was getting reasonably sidetracked at the moment working on it.  As a result, I'm committing the initial work in case it's useful and also to verify that I'm not on the completely wrong track on what needs to happen here.