### PR TITLE
Simplify Turnt config

### DIFF
--- a/caiman-test/core/turnt.toml
+++ b/caiman-test/core/turnt.toml
@@ -1,1 +1,8 @@
-command = "cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {filename} --output ../src/bin/{base}_generated.rs > {base}.log && cat ../src/test_data1.txt > ../src/bin/{base}.rs && printf '{base}' >> ../src/bin/{base}.rs && cat ../src/test_data2.txt >> ../src/bin/{base}.rs && cat {base}.rs >> ../src/bin/{base}.rs && cargo run --manifest-path ../Cargo.toml --bin {base}"
+command = """
+cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {filename} --output ../src/bin/{base}_generated.rs > {base}.log
+cat ../src/test_data1.txt > ../src/bin/{base}.rs
+printf '{base}' >> ../src/bin/{base}.rs
+cat ../src/test_data2.txt >> ../src/bin/{base}.rs
+cat {base}.rs >> ../src/bin/{base}.rs
+cargo run --manifest-path ../Cargo.toml --bin {base}
+"""

--- a/caiman-test/core/turnt.toml
+++ b/caiman-test/core/turnt.toml
@@ -1,8 +1,10 @@
 command = """
 cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {filename} --output ../src/bin/{base}_generated.rs > {base}.log
 cat ../src/test_data1.txt > ../src/bin/{base}.rs
-printf '{base}' >> ../src/bin/{base}.rs
-cat ../src/test_data2.txt >> ../src/bin/{base}.rs
+
+echo '#![allow(warnings)]' > ../src/bin/{base}.rs
+echo 'mod pipeline {{ include!("{base}_generated.rs"); }}' >> ../src/bin/{base}.rs
+
 cat {base}.rs >> ../src/bin/{base}.rs
 cargo run --manifest-path ../Cargo.toml --bin {base}
 """

--- a/caiman-test/ron/turnt.toml
+++ b/caiman-test/ron/turnt.toml
@@ -1,1 +1,9 @@
-command = "cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {filename} --output ../src/bin/{base}_generated.rs > {base}.log && cat ../src/test_data1.txt > ../src/bin/{base}.rs && printf '{base}' >> ../src/bin/{base}.rs && cat ../src/test_data2.txt >> ../src/bin/{base}.rs && cat {base}.rs >> ../src/bin/{base}.rs && cargo run --manifest-path ../Cargo.toml --bin {base}"
+command = """
+cargo run --manifest-path ../../Cargo.toml --features=build-binary -- --input {filename} --output ../src/bin/{base}_generated.rs > {base}.log
+
+echo '#![allow(warnings)]' > ../src/bin/{base}.rs
+echo 'mod pipeline {{ include!("{base}_generated.rs"); }}' >> ../src/bin/{base}.rs
+cat {base}.rs >> ../src/bin/{base}.rs
+
+cargo run --manifest-path ../Cargo.toml --bin {base}
+"""

--- a/caiman-test/src/test_data1.txt
+++ b/caiman-test/src/test_data1.txt
@@ -1,2 +1,0 @@
-#![allow(warnings)]
-mod pipeline { include!("

--- a/caiman-test/src/test_data2.txt
+++ b/caiman-test/src/test_data2.txt
@@ -1,1 +1,0 @@
-_generated.rs"); }


### PR DESCRIPTION
As a follow-up to #36, this simplifies the Turnt configuration by (a) using TOML's multi-line strings to avoid the need for `&&`-joined shell scripts, and (b) echoing the relevant code directly in the script, instead of requiring `test_data*.txt`.