### PR TITLE
Store the actual shader datastructure inside GpuKernel

### DIFF
--- a/caiman-test/ron/pipeline_1_test.ron
+++ b/caiman-test/ron/pipeline_1_test.ron
@@ -10,7 +10,7 @@
 				2 : CpuPureOperation((name : "do_thing_on_cpu", input_types : [0], output_types : [0])),
 				0 : GpuKernel((
 					name : "do_thing_on_gpu", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : None), (group : 0, binding : 1, input : None, output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) readonly buffer Input_0 {
@@ -27,7 +27,7 @@
 				)),
 				1 : GpuKernel((
 					name : "do_thing_on_gpu_2", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) buffer InputOutput_0 {
@@ -562,7 +562,7 @@
 		external_gpu_functions : [
 			(
 				name : "do_thing_on_gpu", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : None), (group : 0, binding : 1, input : None, output : Some(0))],
-				shader_module_content : Wgsl
+				shader_module : Wgsl
 				("
 					struct Output {field_0 : i32;};
 					fn do_thing_on_gpu(a : i32) -> Output 

--- a/caiman-test/ron/pipeline_looping_value_function_test.ron
+++ b/caiman-test/ron/pipeline_looping_value_function_test.ron
@@ -10,7 +10,7 @@
 				2 : CpuPureOperation((name : "do_thing_on_cpu", input_types : [0], output_types : [0])),
 				0 : GpuKernel((
 					name : "do_thing_on_gpu", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : None), (group : 0, binding : 1, input : None, output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) readonly buffer Input_0 {
@@ -27,7 +27,7 @@
 				)),
 				1 : GpuKernel((
 					name : "do_thing_on_gpu_2", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) buffer InputOutput_0 {

--- a/caiman-test/ron/pipeline_value_function_test.ron
+++ b/caiman-test/ron/pipeline_value_function_test.ron
@@ -10,7 +10,7 @@
 				2 : CpuPureOperation((name : "do_thing_on_cpu", input_types : [0], output_types : [0])),
 				0 : GpuKernel((
 					name : "do_thing_on_gpu", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : None), (group : 0, binding : 1, input : None, output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) readonly buffer Input_0 {
@@ -27,7 +27,7 @@
 				)),
 				1 : GpuKernel((
 					name : "do_thing_on_gpu_2", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) buffer InputOutput_0 {

--- a/caiman-test/ron/scheduling_explication_basic_test.ron
+++ b/caiman-test/ron/scheduling_explication_basic_test.ron
@@ -10,7 +10,7 @@
 				2 : CpuPureOperation((name : "do_thing_on_cpu", input_types : [0], output_types : [0])),
 				0 : GpuKernel((
 					name : "do_thing_on_gpu", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : None), (group : 0, binding : 1, input : None, output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) readonly buffer Input_0 {
@@ -27,7 +27,7 @@
 				)),
 				1 : GpuKernel((
 					name : "do_thing_on_gpu_2", input_types : [0], output_types : [0], entry_point : "main", resource_bindings : [(group : 0, binding : 0, input : Some(0), output : Some(0))],
-					shader_module_content : Glsl
+					shader_module : Glsl
 					("
 						#version 450
 						layout(set = 0, binding = 0) buffer InputOutput_0 {

--- a/src/assembly/ast_to_ir.rs
+++ b/src/assembly/ast_to_ir.rs
@@ -6,6 +6,7 @@ use crate::assembly_ast::{
     StorageTypeId, TypeId, ValueFunctionId,
 };
 use crate::ir::ffi;
+use crate::shadergen::ShaderModule;
 use crate::{assembly_ast, frontend, ir};
 use std::any::Any;
 use std::collections::HashMap;
@@ -506,9 +507,9 @@ fn ir_external_gpu(
         .map(|s| s.to_str())
         .flatten()
         .unwrap_or("");
-    let shader_module_content = match input_extension {
-        "wgsl" => ffi::ShaderModuleContent::Wgsl(text_content),
-        "glsl" | "comp" => ffi::ShaderModuleContent::Glsl(text_content),
+    let shader_module = match input_extension {
+        "wgsl" => ShaderModule::from_wgsl(&text_content).unwrap(),
+        "glsl" | "comp" => ShaderModule::from_glsl(&text_content).unwrap(),
         _ => panic!("unknown shader type"),
     };
 
@@ -518,7 +519,7 @@ fn ir_external_gpu(
         output_types: output_types.into_boxed_slice(),
         entry_point: external.entry_point.clone(),
         resource_bindings: resource_bindings.into_boxed_slice(),
-        shader_module_content,
+        shader_module,
     })
 }
 

--- a/src/rust_wgpu_backend/ffi.rs
+++ b/src/rust_wgpu_backend/ffi.rs
@@ -1,3 +1,4 @@
+use crate::shadergen::ShaderModule;
 use crate::stable_vec::StableVec;
 use serde_derive::{Deserialize, Serialize};
 
@@ -141,12 +142,6 @@ pub struct GpuKernelResourceBinding {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum ShaderModuleContent {
-    Wgsl(String),
-    Glsl(String),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GpuKernel {
     pub name: String,
     pub input_types: Box<[TypeId]>,
@@ -154,8 +149,7 @@ pub struct GpuKernel {
     // Contains pipeline and single render pass state
     pub entry_point: String,
     pub resource_bindings: Box<[GpuKernelResourceBinding]>,
-    pub shader_module_content: ShaderModuleContent,
-    //pub shader_module : usize,
+    pub shader_module: ShaderModule,
 }
 
 impl GpuKernel {


### PR DESCRIPTION
This avoids a lot of deserialization/reserialization inside kernel fusion. We don't want RON serialization to depend on Naga, so the current system of string serialization is maintained (although the field was renamed).