### PR TITLE
Elide temporary allocations in kernel fusion

### DIFF
--- a/caiman-test/optimizations/kernel_fusion_test.cair
+++ b/caiman-test/optimizations/kernel_fusion_test.cair
@@ -88,8 +88,10 @@ schedule @fusion_elide_sched(
     %d_gpu = alloc-temporary-gpu-f32 @fusion.%d;
     %_ = encode-copy-gpu %d_local %d_gpu;
 
-    // These three allocations should be elided via static analysis
     %ab_gpu = alloc-temporary-gpu-f32 @fusion.%ab;
+    // This allocation should be elided via static analysis
+    // We could elide ab_gpu too in theory, but in practice it won't be a part of the fused
+    // kernel due to the "contiguous dependency chain" requirement.
     %cd_gpu = alloc-temporary-gpu-f32 @fusion.%cd;
     %ab_cd_gpu = alloc-temporary-gpu-f32 @fusion.%ab_cd;
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -9,6 +9,7 @@ use crate::stable_vec::StableVec;
 
 pub use crate::rust_wgpu_backend::ffi;
 
+pub mod analysis;
 pub mod fusion;
 pub mod validation;
 

--- a/src/ir/analysis.rs
+++ b/src/ir/analysis.rs
@@ -1,0 +1,38 @@
+use crate::ir;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::ops::RangeInclusive;
+
+pub type LiveRangeMap = HashMap<ir::NodeId, RangeInclusive<ir::NodeId>>;
+
+/// Analyzes the given funclet and returns a hashmap which maps node IDs to their "live range". I
+/// define the live range as the range from the first use *after* the node to their last use. A
+/// node which is never used after it's created will have a live range of `None`. I define a "use"
+/// as a read OR a write, which is once again different from standard use/def terminology.
+///
+/// Note that this is the live range of the node's result, so it's pretty meaningless for stuff like
+/// function dispatches. However, for allocations, this is quite meaningful!
+pub fn live_ranges(funclet: &ir::Funclet) -> LiveRangeMap {
+    let mut ranges = HashMap::new();
+
+    fn update_live_range(ranges: &mut LiveRangeMap, nodeId: ir::NodeId, referrer: ir::NodeId) {
+        match ranges.entry(nodeId) {
+            Entry::Occupied(mut existingRange) => {
+                existingRange.insert(*existingRange.get().start()..=referrer);
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(referrer..=referrer);
+            }
+        }
+    }
+
+    for (referrer, node) in funclet.nodes.iter().enumerate() {
+        // TODO: This is a bit dumb, we discard the map result and just use it for the
+        // side effects. Really, there should be a more general way to iterate over references
+        let _ = node.map_referenced_nodes(|nodeId| {
+            update_live_range(&mut ranges, nodeId, referrer);
+            nodeId
+        });
+    }
+    return ranges;
+}

--- a/src/ir/fusion.rs
+++ b/src/ir/fusion.rs
@@ -299,7 +299,9 @@ impl<'a> FuseState<'a> {
                 res.output = Some(output_id);
             }
         }
-
+        //dbg!(&elided_temps);
+        //dbg!(&outputs);
+        //dbg!(&inputs);
         let kernel = ffi::GpuKernel {
             // The name doesn't *really* matter, but we can uniquely identify each fused shader
             // by it's scheduling funclet ID and the starting node (fuse sequences are disjoint)

--- a/src/rust_wgpu_backend/codegen.rs
+++ b/src/rust_wgpu_backend/codegen.rs
@@ -518,18 +518,20 @@ impl<'program> CodeGen<'program> {
         // << removed remappings of dimensions and arguments, since they're only used for codegen >>
 
         // The variable IDs corresponding to the output slots should already exist since this
-        // is strictly called after the header.
-        let output_var_ids: Box<[VarId]> = output_slot_ids
+        // is strictly called after the header, unless one of those output slots was elided.
+        let output_var_ids: Box<[Option<VarId>]> = output_slot_ids
             .iter()
-            .map(|&x| placement_state.get_slot_var_id(x).unwrap())
+            .map(|&x| placement_state.get_slot_var_id(x))
             .collect();
 
         for i in 0..kernel.output_types.len() {
-            placement_state.update_slot_state(
-                output_slot_ids[i],
-                ir::ResourceQueueStage::Encoded,
-                output_var_ids[i],
-            );
+            if let Some(ovi) = output_var_ids[i] {
+                placement_state.update_slot_state(
+                    output_slot_ids[i],
+                    ir::ResourceQueueStage::Encoded,
+                    ovi,
+                );
+            }
         }
     }
     fn encode_do_node_gpu(
@@ -1470,7 +1472,7 @@ impl<'program> CodeGen<'program> {
         let live_ranges = ir::analysis::live_ranges(funclet);
         let fusion_info =
             ir::fusion::FusionInfo::within_funclet(self.program, funclet_id, funclet, &live_ranges);
-        dbg!(&fusion_info.elided_temps);
+        // dbg!(&fusion_info.elided_temps);
 
         if self.print_codegen_debug_info {
             println!(
@@ -1525,8 +1527,8 @@ impl<'program> CodeGen<'program> {
                             .unwrap(),
                         operation.funclet_id
                     );
-                    // We *could* do unused temporary elision here, but after writing test cases
-                    // I discovered that codegen panics if any slots are unused.
+                    // We *could* also do unused temporary elision here, but after writing test
+                    // cases I discovered that codegen panics if any slots are unused.
                     let slot_id = placement_state.scheduling_state.insert_hacked_slot(
                         *storage_type,
                         *place,
@@ -1540,10 +1542,11 @@ impl<'program> CodeGen<'program> {
                             storage_type: *storage_type,
                         },
                     );
+                    if fusion_info.elided_temps.contains(&current_node_id) {
+                        continue;
+                    }
 
                     // To do: Allocate from buffers for GPU/CPU and assign variable
-                    // TODO: Elide this if the temporary is small enough and *strictly* used
-                    // as an input to a single real kernel dispatch
                     match place {
                         ir::Place::Cpu => (),
                         ir::Place::Local => (),

--- a/src/rust_wgpu_backend/ffi.rs
+++ b/src/rust_wgpu_backend/ffi.rs
@@ -116,6 +116,34 @@ pub enum Type {
     },
 }
 
+impl Type {
+    pub fn estimate_size(&self, types: &StableVec<Type>) -> usize {
+        match self {
+            Self::F32 => 4,
+            Self::F64 => 8,
+            Self::U8 => 1,
+            Self::U16 => 2,
+            Self::U32 => 4,
+            Self::U64 => 8,
+            Self::USize => std::mem::size_of::<usize>(),
+            Self::I8 => 1,
+            Self::I16 => 2,
+            Self::I32 => 4,
+            Self::I64 => 8,
+            Self::Array {
+                element_type,
+                length,
+            } => {
+                // assuming no padding, probably incorrect
+                // that's ok though, this is only an estimate
+                return length * types[element_type.0].estimate_size(types);
+            }
+            // TODO: finish this for other types
+            _ => usize::MAX,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CpuPureOperation {
     pub name: String,


### PR DESCRIPTION
After allocation, if a temporary-allocated GPU slot is exclusively used within the bounds of one fuse sequence, the allocation is removed and its binding is converted into a global variable within the compute shader.

There are some rough edges in this PR that should be resolved in the future. First, I'm not sure whether I'm correctly upholding codegen's invariants. The optimization is theoretically sound but I might be forgetting to update some data structures or updating others when I shouldn't. It passes all test cases, though! Second, `FuseState::finish` has grown incredibly ugly and should be refactored at some point.