### PR TITLE
Parsing Fixes

### DIFF
--- a/caiman-test/explication/basics/trivial_baseline.cair
+++ b/caiman-test/explication/basics/trivial_baseline.cair
@@ -1,26 +1,32 @@
 version 0.0.2
 
 type i64;
-slot %slot0 : i64-ready-local;
-event %event0 : local;
+event %event0;
+buffer_space %buffspace;
+native_value %ni64 : i64;
 
 function @main() -> i64;
 
 value[impl default @main] %foo() -> i64 {
-    %x = constant 4i64;
+    %x = constant %ni64 4;
     return %x;
-}
-
-schedule[value $val = %foo, timeline $time = %time]
-%bar<input($time.%e), output($time.%e)>() ->
-[%out : %slot0] {
-    %x_loc = alloc-temporary-local-i64 %foo.%x;
-    %_ = encode-do-local %foo.%x() -> %x_loc;
-    return %x_loc;
 }
 
 timeline %time(%e : %event0) -> %event0 {
     return %e;
+}
+
+spatial %space(%bs : %buffspace) -> %buffspace {
+    return %bs;
+}
+
+schedule[value $val = %foo, timeline $time = %time, spatial $space = %space]
+%bar<none($time.%e)-have, none($time.%e)-have>() ->
+[%out : %ni64] {
+    %x_ref = alloc-temporary local [] i64;
+    local-do-builtin node($val.%x)() -> %x_ref;
+    %result = read-ref i64 %x_ref;
+    return %result;
 }
 
 pipeline "main" = %bar;

--- a/caiman-test/reference_untested/example.cair
+++ b/caiman-test/reference_untested/example.cair
@@ -29,9 +29,9 @@ type cpu_buffer_allocator;
 type cpu_buffer_ref<i64>;
 
 native_value %native_i64 : i64;
-ref %slot0 : i64-local;
+ref %slot0 : i64-local<flags=[map_read,map_write,copy_src,copy_dst,storage,uniform]>;
 fence %fence0 : cpu;
-buffer %buffer0 : gpu<alignment_bits = 4, byte_size = 8>;
+buffer %buffer0 : gpu<flags = [], alignment_bits = 4, byte_size = 8>;
 encoder %encoder0 : gpu;
 event %event0;
 buffer_space %buffer_space0;
@@ -86,16 +86,15 @@ spatial %space(%b : %buffer_space0) -> [%iout : i64] {
 }
 
 // can syntactically be empty, even though this is meaningless
-schedule[value $val = %foo] %bar<none, none-none>(%0 : %slot0) -> [%out : %slot0] {
-    %x = alloc-temporary local i64;
+schedule[value $val = %foo] %bar<none($val)-have, none($time)-none>(%0 : %slot0) -> [%out : %slot0] {
+    %x = alloc-temporary local [copy_dst, copy_src] i64;
     drop %0;
     %y = static-sub-alloc local i64 %x;
-    %4 = static-alloc local %0 [1, 2] input(?);
-    %z = static-dealloc local node($val.%5) [%x, %4];
+    %z = static-split local %y [1, 2, 3] ?;
     %_ = read-ref i64 %x;
     %_ = borrow-ref i64 %x;
     write-ref i64 %x -> %4;
-    local-do-builtin none(%x, %3) -> [%4, %0];
+    local-do-builtin none($space)(%x, %3) -> [%4, %0];
     local-do-external %do_pure_thing_on_cpu output(?)(%x, %3) -> [%4, %0];
     local-copy %x -> %3;
     %_ = begin-encoding local node(?.?)[%x, %3] [%4, %0];

--- a/caiman-test/reference_untested/example.cair
+++ b/caiman-test/reference_untested/example.cair
@@ -86,7 +86,7 @@ spatial %space(%b : %buffer_space0) -> [%iout : i64] {
 }
 
 // can syntactically be empty, even though this is meaningless
-schedule[value $val = %foo] %bar<none($val)-have, none($time)-none>(%0 : %slot0) -> [%out : %slot0] {
+schedule[value $val = %foo] %bar<none($val)-have, none($val)-none>(%0 : %slot0) -> [%out : %slot0] {
     %x = alloc-temporary local [copy_dst, copy_src] i64;
     drop %0;
     %y = static-sub-alloc local i64 %x;
@@ -94,7 +94,7 @@ schedule[value $val = %foo] %bar<none($val)-have, none($time)-none>(%0 : %slot0)
     %_ = read-ref i64 %x;
     %_ = borrow-ref i64 %x;
     write-ref i64 %x -> %4;
-    local-do-builtin none($space)(%x, %3) -> [%4, %0];
+    local-do-builtin none($val)(%x, %3) -> [%4, %0];
     local-do-external %do_pure_thing_on_cpu output(?)(%x, %3) -> [%4, %0];
     local-copy %x -> %3;
     %_ = begin-encoding local node(?.?)[%x, %3] [%4, %0];
@@ -112,14 +112,14 @@ schedule[value $val = %foo] %bar<none($val)-have, none($time)-none>(%0 : %slot0)
     return %x;
 }
 
-schedule[value $val = %foo, spatial $space = %space]
-%scall<none-have, none-met>
+schedule[value $val = %foo, timeline $time = %time, spatial $space = %space]
+%scall<none($time)-have, none($time)-met>
 (%abc : input($val.%x)-have %slot0)
 -> [%out : output($val.%y)-met %slot0] {
     // Note that these are not parser-bound by funclet type, but (should be) managed by the typechecker
     schedule-call %bar[value input(?),
         timeline output(?),
-        spatial none](%abc, %abc) %abc;
+        spatial none($space)](%abc, %abc) %abc;
 }
 
 // value, timeline, spatial order is mandatory (though you can freely omit one of course)
@@ -129,16 +129,16 @@ schedule[value $val = %foo, timeline $time = %tim, spatial $space = %space]
 -> input($time.%e)-met output($val.%x)-none %slot0 {
     schedule-select %abc [%bar, %scall][value input(?),
         timeline output(?),
-        spatial none](%abc, %abc) %abc;
+        spatial none($space)](%abc, %abc) %abc;
 }
 
-schedule[value $val = %foo, timeline $time = %time]
+schedule[value $val = %foo, timeline $time = %time, spatial $space = %space]
 %syield<input($time.%e)-have, node($time.%e)-need>
 (%abc : input($time.%bs)-none %event0)
 -> [%out : node($time.%bs)-need %buffer0] {
     schedule-call-yield %bar[value input($val.%x),
         timeline output($time.%e),
-        spatial none](%abc, %abc) %abc;
+        spatial none($space)](%abc, %abc) %abc;
 }
 
 schedule[value $val = %foo, timeline $time = %time, spatial $space = %space]

--- a/caiman-test/test.py
+++ b/caiman-test/test.py
@@ -33,14 +33,14 @@ def eprint(*args, **kwargs):
     print(*args, file=stderr, **kwargs)
 
 class Colorizer:
-    def cyan(s: str) -> str:
-        return f"\033[36m{s}\033[39m"
-    def yellow(s: str) -> str:
-        return f"\033[93m{s}\033[39m"
-    def red(s: str) -> str:
-        return f"\033[31m{s}\033[39m"
-    def grey(s: str) -> str:
-        return f"\033[90m{s}\033[39m"
+    def cyan(self: str) -> str:
+        return f"\033[36m{self}\033[39m"
+    def yellow(self: str) -> str:
+        return f"\033[93m{self}\033[39m"
+    def red(self: str) -> str:
+        return f"\033[31m{self}\033[39m"
+    def grey(self: str) -> str:
+        return f"\033[90m{self}\033[39m"
 
 COLOR_INFO = Colorizer.cyan("[info]")
 COLOR_WARN = Colorizer.yellow("[warn]")

--- a/src/assembly/caimanir.pest
+++ b/src/assembly/caimanir.pest
@@ -30,7 +30,7 @@ function_class_name = ${ "@" ~ id }
 function_class_name_sep = ${ function_class_name ~ sep }
 name_hole = { name | hole }
 name_hole_sep = ${ name_hole ~ sep }
-meta_name = ${ "$" ~ (id | throwaway) }
+meta_name = ${ "$" ~ id }
 meta_name_sep = ${ meta_name ~ sep }
 meta_name_hole = { meta_name | hole }
 meta_name_hole_sep = ${ meta_name_hole ~ sep }
@@ -60,13 +60,13 @@ place = @{ "local" | "cpu" | "gpu" }
 place_sep = ${ place ~ sep }
 place_hole = { place | hole }
 place_hole_sep = ${ place_hole ~ sep }
-buffer_flag = @{ "map_read" | "map_write" | "copy_src" | "copy_dst" | "storage" | "unform" }
+buffer_flag = @{ "map_read" | "map_write" | "copy_src" | "copy_dst" | "storage" | "uniform" }
 buffer_flags_elements = !{ (buffer_flag ~ ("," ~ buffer_flag)*)? }
 buffer_flags = { "[" ~ buffer_flags_elements ~ "]" }
 
-meta_remote = { meta_name ~ "." ~ name }
-meta_remote_hole = { meta_name_hole ~ "." ~ name_hole | hole }
-quotient_name = { "node" | "input" | "output" | "halt" | "none" }
+meta_remote = { meta_name | meta_name ~ "." ~ name }
+meta_remote_hole = { meta_name_hole | meta_name_hole ~ "." ~ name_hole | hole }
+quotient_name = { "node" | "input" | "output" | "none" }
 quotient = !{ quotient_name ~ "(" ~ meta_remote ~ ")" }
 quotient_hole = !{ quotient_name ~ "(" ~ meta_remote_hole ~ ")" | hole }
 flow = { "none" | "have" | "met" | "need" }
@@ -84,11 +84,14 @@ ffi_type_decl = ${ "type" ~ sep ~ ffi_type }
 
 name_type_separator = !{ name ~ ":" ~ "" }
 native_value_decl = ${ "native_value" ~ sep ~ name_type_separator ~ typ }
-ref_decl = ${ "ref" ~ sep ~ name_type_separator ~ typ ~ "-" ~ place ~ "<" ~ "flags" ~ "=" ~ buffer_flags ~ ">" }
+ref_buffer = { "<" ~ "flags" ~ "=" ~ buffer_flags ~ ">" }
+ref_type = ${  typ ~ "-" ~ place }
+ref_decl = { "ref" ~ name_type_separator ~ ref_type ~ ref_buffer }
 fence_decl = ${ "fence" ~ sep ~ name_type_separator ~ place }
 buffer_alignment_decl = !{ name ~ ":" ~ place ~ "<"
     ~ "flags" ~ "=" ~ buffer_flags ~ ","
-    ~ "alignment_bits" ~ "=" ~ n ~ "," ~ "byte_size" ~ "=" ~ n ~ ">" }
+    ~ "alignment_bits" ~ "=" ~ n ~ ","
+    ~ "byte_size" ~ "=" ~ n ~ ">" }
 
 buffer_decl = ${ "buffer" ~ sep ~ buffer_alignment_decl }
 encoder_sep = ${"encoder" ~ sep}
@@ -247,6 +250,7 @@ static_sub_alloc_sep = ${ "static-sub-alloc" ~ sep }
 static_sub_alloc_node = { assign ~ static_sub_alloc_sep ~ place_hole_sep ~ type_hole_sep ~ name_hole }
 static_split_sep = ${ "static-split" ~ sep }
 static_split_node = { assign ~ static_split_sep ~ place_hole_sep ~ name_hole ~ n_list ~ quotient_hole }
+// static_split_node = { assign ~ static_split_sep ~ place_hole_sep ~ name_hole ~ n_list ~ quotient_hole }
 static_merge_sep = ${ "static-merge" ~ sep }
 static_merge_node = { assign ~ static_merge_sep ~ place_hole_sep ~ quotient_hole ~ name_box }
 

--- a/src/assembly/caimanir.pest
+++ b/src/assembly/caimanir.pest
@@ -64,8 +64,8 @@ buffer_flag = @{ "map_read" | "map_write" | "copy_src" | "copy_dst" | "storage" 
 buffer_flags_elements = !{ (buffer_flag ~ ("," ~ buffer_flag)*)? }
 buffer_flags = { "[" ~ buffer_flags_elements ~ "]" }
 
-meta_remote = { meta_name | meta_name ~ "." ~ name }
-meta_remote_hole = { meta_name_hole | meta_name_hole ~ "." ~ name_hole | hole }
+meta_remote = { meta_name ~ ("." ~ name)? }
+meta_remote_hole = { meta_name_hole ~ ("." ~ name_hole)? | hole }
 quotient_name = { "node" | "input" | "output" | "none" }
 quotient = !{ quotient_name ~ "(" ~ meta_remote ~ ")" }
 quotient_hole = !{ quotient_name ~ "(" ~ meta_remote_hole ~ ")" | hole }


### PR DESCRIPTION
Fixes some issues with the parser (and the [reference implementation](https://github.com/cucapra/caiman/blob/main/caiman-test/reference_untested/example.cair) for syntax).  Should be up-to-date with the changes made to tags now.  We may consider wanting to rework some of the syntax to better match tags, most notably considering getting rid of `value` and `timeline` in arguments when these are already part of the quotient.