### PR TITLE
Fix Alloc Temp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/caiman-rt/src/lib.rs
+++ b/caiman-rt/src/lib.rs
@@ -228,7 +228,8 @@ impl LocalVars {
         let type_id = std::any::TypeId::of::<T>();
         self.type_ids.insert(id, type_id);
         let mut r = unsafe {
-            (self.storage.alloc(id, size, align) as *mut c_void)
+            self.storage
+                .alloc(id, size, align)
                 .cast::<std::mem::MaybeUninit<T>>()
                 .as_mut()
                 .unwrap()

--- a/caiman-rt/src/lib.rs
+++ b/caiman-rt/src/lib.rs
@@ -1,9 +1,159 @@
 #![allow(warnings)]
+
+use core::slice;
+use std::{
+    alloc::Layout, any::Any, collections::HashMap, fmt::Alignment, marker::PhantomData,
+    mem::MaybeUninit, os::raw::c_void,
+};
+
+use wgpu::Buffer;
 pub extern crate bytemuck;
 pub extern crate wgpu;
 
 // None = waits on whole queue
 pub type GpuFence = Option<wgpu::SubmissionIndex>;
+
+/// Manages the allocation of variables in a contiguous buffer,
+/// respecting the alignment requirements of each variable.
+struct BumpAllocator {
+    buffer_align: usize,
+    // next available address in the buffer
+    next_address: usize,
+    // map from variable ids to their starting addresses
+    address_map: HashMap<usize, BumpAddr>,
+    buffer_len: usize,
+}
+
+/// An offset off of the start of the buffer.
+#[derive(Debug, Copy, Clone)]
+struct BumpAddr(usize);
+
+const DEFAULT_ALIGN: usize = 16;
+
+impl BumpAllocator {
+    /// Creates a new allocator with the given buffer size and alignment of
+    /// the buffer itself.
+    fn new(size: usize, align: usize) -> Self {
+        Self {
+            next_address: 0,
+            address_map: HashMap::new(),
+            buffer_len: size,
+            buffer_align: align,
+        }
+    }
+
+    /// Allocates a new variable with the given id, size, and alignment.
+    /// The alignment must be less than or equal to `MAX_ALIGN`.
+    fn alloc(&mut self, id: usize, size: usize, align: usize) -> BumpAddr {
+        let next_aligned_addr = ((self.next_address + self.buffer_align + align - 1)
+            & !(align - 1))
+            - self.buffer_align;
+        assert!(next_aligned_addr + size <= self.buffer_len);
+        self.next_address = next_aligned_addr + size;
+        let addr = BumpAddr(next_aligned_addr);
+        self.address_map.insert(id, addr);
+        addr
+    }
+
+    /// Gets a pointer to the start of the allocation for the given id.
+    /// Requires that the allocation exists and that usage of the pointer is safe.
+    fn get_starting_addr(&self, id: usize) -> BumpAddr {
+        *self.address_map.get(&id).unwrap()
+    }
+
+    /// Resets the allocator to the empty state, essentially erase all allocations.
+    fn reset(&mut self) {
+        self.next_address = 0;
+        self.address_map.clear();
+    }
+}
+
+/// Allocates data on the CPU.
+struct CpuAllocator {
+    buffer: Box<[u8]>,
+    allocator: BumpAllocator,
+}
+
+impl CpuAllocator {
+    pub fn new(size: usize) -> Self {
+        Self {
+            buffer: unsafe {
+                Box::from_raw(slice::from_raw_parts_mut(
+                    std::alloc::alloc_zeroed(Layout::from_size_align(size, DEFAULT_ALIGN).unwrap()),
+                    size,
+                ))
+            },
+            allocator: BumpAllocator::new(size, DEFAULT_ALIGN),
+        }
+    }
+
+    /// Allocates a local variable with the given id, size, and alignment
+    /// and returns a mutable reference to it.
+    ///
+    /// Panics if the buffer is full
+    pub fn alloc(&mut self, id: usize, size: usize, align: usize) -> *mut c_void {
+        self.allocator.alloc(id, size, align);
+        self.get_ptr_mut(id)
+    }
+
+    /// Gets the starting address of the allocation for the given id.
+    pub fn get_ptr(&self, id: usize) -> *const c_void {
+        unsafe {
+            self.buffer
+                .as_ptr()
+                .add(self.allocator.get_starting_addr(id).0) as *const c_void
+        }
+    }
+
+    /// Gets the starting address of the allocation for the given id.
+    pub fn get_ptr_mut(&mut self, id: usize) -> *mut c_void {
+        unsafe {
+            self.buffer
+                .as_mut_ptr()
+                .add(self.allocator.get_starting_addr(id).0) as *mut c_void
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.allocator.reset();
+    }
+}
+
+/// Allocates data on the GPU.
+struct GpuAllocator {
+    buffer: Buffer,
+    allocator: BumpAllocator,
+}
+
+impl GpuAllocator {
+    pub fn new(state: &mut dyn State, usage: wgpu::BufferUsages) -> Self {
+        const BUFFER_SIZE: u64 = 4096;
+        Self {
+            buffer: state
+                .get_device_mut()
+                .create_buffer(&wgpu::BufferDescriptor {
+                    label: None,
+                    size: BUFFER_SIZE,
+                    usage,
+                    mapped_at_creation: false,
+                }),
+            allocator: BumpAllocator::new(BUFFER_SIZE as usize, 0),
+        }
+    }
+
+    pub fn alloc(&mut self, id: usize, size: usize, align: usize) {
+        self.allocator.alloc(id, size, align);
+    }
+
+    pub fn get_buffer_ref<T: Sized + Any>(&self, id: usize) -> GpuBufferRef<'_, T> {
+        let addr = self.allocator.get_starting_addr(id);
+        GpuBufferRef::new(&self.buffer, addr.0 as wgpu::BufferAddress)
+    }
+
+    pub fn reset(&mut self) {
+        self.allocator.reset();
+    }
+}
 
 pub trait State {
     fn get_device_mut(&mut self) -> &mut wgpu::Device;
@@ -13,11 +163,16 @@ pub trait State {
 pub struct RootState<'device, 'queue> {
     device: &'device mut wgpu::Device,
     queue: &'queue mut wgpu::Queue,
+    local_storage: CpuAllocator,
 }
 
 impl<'device, 'queue> RootState<'device, 'queue> {
     pub fn new(device: &'device mut wgpu::Device, queue: &'queue mut wgpu::Queue) -> Self {
-        Self { device, queue }
+        Self {
+            device,
+            queue,
+            local_storage: CpuAllocator::new(4096 * 4),
+        }
     }
 }
 
@@ -28,6 +183,170 @@ impl<'device, 'queue> State for RootState<'device, 'queue> {
 
     fn get_queue_mut(&mut self) -> &mut wgpu::Queue {
         self.queue
+    }
+}
+
+/// Manages the allocation of local variables on the CPU.
+/// The variables are allocated in a contiguous buffer, respecting their alignment requirements.
+pub struct LocalVars {
+    storage: CpuAllocator,
+    // maps variable ids to their type ids. Used only for runtime checks
+    type_ids: HashMap<usize, std::any::TypeId>,
+}
+
+const GPU_BUFFERS: usize = 5;
+
+/// Manages the allocation of local variables on the GPU.
+/// Kept separate from `LocalVars` to make it possible to have a GPU and CPU
+/// reference live at the same time (ie. mutable borrow from two different
+/// objects instead of one).
+pub struct GpuLocals {
+    // one allocator for each buffer usage, index of buffer usage
+    // maps to the index of the allocator
+    gpu_allocators: [GpuAllocator; GPU_BUFFERS],
+    usages: [wgpu::BufferUsages; GPU_BUFFERS],
+    // maps variable ids to the index of the gpu allocator that holds them
+    alloc_map: HashMap<usize, usize>,
+    // maps variable ids to their type ids. Used only for runtime checks
+    type_ids: HashMap<usize, std::any::TypeId>,
+}
+
+impl LocalVars {
+    pub fn new() -> Self {
+        const LOCAL_BUF_SIZE: usize = 4096 * 4;
+        Self {
+            storage: CpuAllocator::new(LOCAL_BUF_SIZE),
+            type_ids: HashMap::new(),
+        }
+    }
+
+    /// Helper function to allocate a CPU local variable with the given id, size, and alignment.
+    /// Returns a mutable reference to the allocated memory.
+    fn alloc_uninit<T: Sized + Any>(&mut self, id: usize) -> &mut std::mem::MaybeUninit<T> {
+        let align = std::mem::align_of::<T>();
+        let size = std::mem::size_of::<T>();
+        let type_id = std::any::TypeId::of::<T>();
+        self.type_ids.insert(id, type_id);
+        let mut r = unsafe {
+            (self.storage.alloc(id, size, align) as *mut c_void)
+                .cast::<std::mem::MaybeUninit<T>>()
+                .as_mut()
+                .unwrap()
+        };
+        r
+    }
+
+    /// Allocates a CPU local variable with the given id, size, and alignment.
+    /// The variable is initialized with the given value.
+    pub fn calloc<T: Sized + Any>(&mut self, id: usize, val: T) -> &mut T {
+        let mut r = self.alloc_uninit::<T>(id);
+        r.write(val);
+        unsafe { r.assume_init_mut() }
+    }
+
+    /// Allocates a CPU local variable with the given id, size, and alignment.
+    /// Initializes the variable with the default value of the type.
+    pub fn malloc<T: Sized + Any + Default>(&mut self, id: usize) -> &mut T {
+        self.calloc(id, Default::default())
+    }
+
+    /// Gets a CPU mutable pointer to the start of the allocation for the given id.
+    /// The allocation must have already been created with `alloc_var`
+    pub fn get_mut<T: Sized + Any>(&mut self, id: usize) -> &mut T {
+        assert_eq!(
+            self.type_ids.get(&id).unwrap(),
+            &std::any::TypeId::of::<T>()
+        );
+        unsafe {
+            (self.storage.get_ptr_mut(id) as *mut c_void)
+                .cast::<T>()
+                .as_mut()
+                .unwrap()
+        }
+    }
+    /// Gets a CPU const pointer to the start of the allocation for the given id.
+    /// The allocation must have already been created with `alloc_var`
+    pub fn get<T: Sized + Any>(&self, id: usize) -> &T {
+        assert_eq!(
+            self.type_ids.get(&id).unwrap(),
+            &std::any::TypeId::of::<T>()
+        );
+        unsafe {
+            (self.storage.get_ptr(id) as *const c_void)
+                .cast::<T>()
+                .as_ref()
+                .unwrap()
+        }
+    }
+
+    /// Clears all allocations and resets the allocator to the empty state.
+    pub fn reset(&mut self) {
+        self.storage.reset();
+        self.type_ids.clear();
+    }
+}
+
+impl GpuLocals {
+    pub fn new(state: &mut dyn State) -> Self {
+        let usages = [
+            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::MAP_READ,
+            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::MAP_WRITE,
+            wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::STORAGE,
+            wgpu::BufferUsages::MAP_READ
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::STORAGE,
+        ];
+        Self {
+            gpu_allocators: [
+                GpuAllocator::new(state, usages[0]),
+                GpuAllocator::new(state, usages[1]),
+                GpuAllocator::new(state, usages[2]),
+                GpuAllocator::new(state, usages[3]),
+                GpuAllocator::new(state, usages[4]),
+            ],
+            usages,
+            alloc_map: HashMap::new(),
+            type_ids: HashMap::new(),
+        }
+    }
+
+    /// Clears all allocations and resets the allocator to the empty state.
+    pub fn reset(&mut self) {
+        self.alloc_map.clear();
+        self.type_ids.clear();
+        for gpu_alloc in self.gpu_allocators.iter_mut() {
+            gpu_alloc.reset();
+        }
+    }
+
+    /// Allocates a GPU local variable with the given id, size, and alignment.
+    pub fn alloc_gpu<T: Sized + Any>(&mut self, id: usize, usage: wgpu::BufferUsages) {
+        for (idx, u) in self.usages.iter().enumerate() {
+            if u.contains(usage) {
+                self.alloc_map.insert(id, idx);
+                self.type_ids.insert(id, std::any::TypeId::of::<T>());
+                self.gpu_allocators[idx].alloc(
+                    id,
+                    std::mem::size_of::<T>(),
+                    std::mem::align_of::<T>()
+                        .max(wgpu::Limits::default().min_storage_buffer_offset_alignment as usize),
+                );
+                return;
+            }
+        }
+        panic!("No suitable GPU buffer usage found for {:?}", usage);
+    }
+
+    /// Gets a GPU mutable pointer to the start of the allocation for the given id.
+    pub fn get_gpu_ref<T: Sized + Any>(&self, id: usize) -> GpuBufferRef<'_, T> {
+        assert_eq!(
+            self.type_ids.get(&id).unwrap(),
+            &std::any::TypeId::of::<T>()
+        );
+        let idx = self.alloc_map.get(&id).unwrap();
+        self.gpu_allocators[*idx].get_buffer_ref(id)
     }
 }
 

--- a/src/rust_wgpu_backend/code_generator.rs
+++ b/src/rust_wgpu_backend/code_generator.rs
@@ -1402,15 +1402,6 @@ impl<'program> CodeGenerator<'program> {
             }
         }
 
-        // write!(self.code_writer, " ) : ( ");
-
-        // for (i, var_type) in var_types.iter().enumerate() {
-        //     write!(self.code_writer, "{}", var_type);
-        //     if i < output_type_ids.len() - 1 {
-        //         write!(self.code_writer, ", ");
-        //     }
-        // }
-
         write!(
             self.code_writer,
             ") = if {} !=0 {{ ",

--- a/src/rust_wgpu_backend/code_generator.rs
+++ b/src/rust_wgpu_backend/code_generator.rs
@@ -62,7 +62,9 @@ enum VariableKind {
 struct VariableTracker {
     id_generator: IdGenerator,
     variable_kinds: HashMap<VarId, VariableKind>,
-    //variable_types: HashMap<VarId, ffi::TypeId>,
+    variable_types: HashMap<VarId, ffi::TypeId>,
+    /// variables allocated via alloc_temporary
+    allocated_temps: HashSet<VarId>,
 }
 
 impl VariableTracker {
@@ -70,7 +72,8 @@ impl VariableTracker {
         Self {
             id_generator: IdGenerator::new(),
             variable_kinds: HashMap::<VarId, VariableKind>::new(),
-            //variable_types: HashMap::<VarId, ffi::TypeId>::new(),
+            variable_types: HashMap::<VarId, ffi::TypeId>::new(),
+            allocated_temps: HashSet::<VarId>::new(),
         }
     }
 
@@ -81,12 +84,32 @@ impl VariableTracker {
     fn create(&mut self, kind: VariableKind, type_id: Option<ffi::TypeId>) -> VarId {
         let id = self.generate();
         self.variable_kinds.insert(id, kind);
-        //self.variable_types.insert(id, type_id);
+        if let Some(type_id) = type_id {
+            self.variable_types.insert(id, type_id);
+        }
         id
     }
 
     fn create_local_data(&mut self, type_id: Option<ffi::TypeId>) -> VarId {
         let id = self.create(VariableKind::LocalData, type_id);
+        id
+    }
+
+    /// Creates a local temporary variable on the CPU. Adds the temporary
+    /// to the set of temporary variables the variable tracker is aware of.
+    fn create_local_alloc(&mut self, type_id: Option<ffi::TypeId>) -> VarId {
+        let id = self.create_local_data(type_id);
+        assert!(!self.allocated_temps.contains(&id));
+        self.allocated_temps.insert(id);
+        id
+    }
+
+    /// Creates a local temporary variable on the GPU. Adds the temporary
+    /// to the set of temporary variables the variable tracker is aware of.
+    fn create_local_gpu(&mut self, type_id: Option<ffi::TypeId>) -> VarId {
+        let id = self.create_buffer(type_id);
+        assert!(!self.allocated_temps.contains(&id));
+        self.allocated_temps.insert(id);
         id
     }
 
@@ -108,8 +131,9 @@ impl VariableTracker {
         self.variable_kinds[&variable_id]
     }
 
-    fn get_var_name(&self, variable_id: VarId) -> String {
-        format!("var_{}", variable_id.0)
+    // Returns if the variable was created by alloc temporary
+    fn is_temp(&self, variable_id: VarId) -> bool {
+        self.allocated_temps.contains(&variable_id)
     }
 }
 
@@ -243,6 +267,10 @@ impl<'program> CodeGenerator<'program> {
         self.type_code_writer.finish()
             + self.state_code_writer.finish().as_str()
             + self.code_writer.finish().as_str()
+    }
+
+    fn get_var_name(&self, variable_id: VarId) -> String {
+        format!("var_{}", variable_id.0)
     }
 
     fn get_tuple_definition_string(&self, type_ids: &[ffi::TypeId]) -> String {
@@ -395,10 +423,11 @@ impl<'program> CodeGenerator<'program> {
                 true,
                 "Binding must be input or output"
             );
+            let variable_id = variable_id.unwrap();
             self.code_writer.write(format!(
                 "wgpu::BindGroupEntry {{binding : {}, resource : {}.as_binding_resource() }}, ",
                 binding,
-                self.variable_tracker.get_var_name(variable_id.unwrap())
+                self.build_get_gpu_ref(variable_id, None)
             ));
         }
         self.code_writer.write("];\n".to_string());
@@ -483,15 +512,15 @@ impl<'program> CodeGenerator<'program> {
         self.begin_command_encoding();
 
         assert_eq!(kernel.input_types.len(), argument_vars.len());
-        self.code_writer.write(format!("let ("));
-        for output_index in 0..kernel.output_types.len() {
-            let var_id = output_vars[output_index];
-            self.code_writer
-                .write(format!("{}, ", self.variable_tracker.get_var_name(var_id)));
-        }
-        self.code_writer.write(format!(") = "));
+        // self.code_writer.write(format!("let ("));
+        // for output_index in 0..kernel.output_types.len() {
+        //     let var_id = output_vars[output_index];
+        //     self.code_writer
+        //         .write(format!("{}, ", self.get_var_name(var_id),));
+        // }
+        // self.code_writer.write(format!(") = "));
 
-        self.code_writer.write("{\n".to_string());
+        // self.code_writer.write("{\n".to_string());
 
         self.code_writer.write_str("{\n");
         self.code_writer.write("let mut compute_pass = command_encoder.begin_compute_pass(& wgpu::ComputePassDescriptor {label : None});\n".to_string());
@@ -499,33 +528,38 @@ impl<'program> CodeGenerator<'program> {
             .write("compute_pass.set_pipeline(& pipeline);\n".to_string());
         self.code_writer
             .write("compute_pass.set_bind_group(0, & bind_group, & []);\n".to_string());
-        self.code_writer.write(format!("compute_pass.dispatch_workgroups({}.try_into().unwrap(), {}.try_into().unwrap(), {}.try_into().unwrap());\n", self.variable_tracker.get_var_name(dimension_vars[0]), self.variable_tracker.get_var_name(dimension_vars[1]), self.variable_tracker.get_var_name(dimension_vars[2])));
-        self.code_writer.write_str("}\n");
+        self.code_writer.write(format!(
+            "compute_pass.dispatch_workgroups(({}).try_into().unwrap(), \
+        ({}).try_into().unwrap(), \
+        ({}).try_into().unwrap());\n",
+            self.access_val_str(dimension_vars[0]),
+            self.access_val_str(dimension_vars[1]),
+            self.access_val_str(dimension_vars[2])
+        ));
+        // self.code_writer.write_str("}\n");
 
-        let mut output_temp_variables = Vec::<VarId>::new();
-        for output_index in 0..kernel.output_types.len() {
-            let staging_var_id = output_vars[output_index];
-            let type_id = kernel.output_types[output_index];
-            let range_var_id = self.variable_tracker.generate();
-            let output_temp_var_id = self.variable_tracker.generate();
-            let slice_var_id = self.variable_tracker.generate();
-            let future_var_id = self.variable_tracker.generate();
-            let type_binding_info = self.get_type_binding_info(type_id);
-            let type_name = self.get_type_name(type_id);
+        // let mut output_temp_variables = Vec::<VarId>::new();
+        // for output_index in 0..kernel.output_types.len() {
+        //     let staging_var_id = output_vars[output_index];
+        //     let type_id = kernel.output_types[output_index];
+        //     let range_var_id = self.variable_tracker.generate();
+        //     let output_temp_var_id = self.variable_tracker.generate();
+        //     let slice_var_id = self.variable_tracker.generate();
+        //     let future_var_id = self.variable_tracker.generate();
+        //     let type_binding_info = self.get_type_binding_info(type_id);
+        //     let type_name = self.get_type_name(type_id);
 
-            output_temp_variables.push(staging_var_id);
-        }
+        //     output_temp_variables.push(staging_var_id);
+        // }
 
-        self.code_writer.write(format!("("));
-        for output_temp_var_id in output_temp_variables.iter() {
-            self.code_writer.write(format!(
-                "{}, ",
-                self.variable_tracker.get_var_name(*output_temp_var_id)
-            ));
-        }
-        self.code_writer.write(format!(")"));
+        // self.code_writer.write(format!("("));
+        // for output_temp_var_id in output_temp_variables.iter() {
+        //     self.code_writer
+        //         .write(format!("{}, ", self.get_var_name(*output_temp_var_id)));
+        // }
+        // self.code_writer.write(format!(")"));
 
-        self.code_writer.write("};\n".to_string());
+        self.code_writer.write("}\n".to_string());
 
         let command_buffer_id = self.end_command_encoding();
         self.enqueue_command_buffer(command_buffer_id);
@@ -578,7 +612,7 @@ impl<'program> CodeGenerator<'program> {
         write!(
             self.code_writer,
             "let {} = Some(submission_index_{});\n",
-            self.variable_tracker.get_var_name(recv_var_id),
+            self.get_var_name(recv_var_id),
             self.submission_queue.last_submission_id_opt.unwrap().0
         );
 
@@ -586,7 +620,7 @@ impl<'program> CodeGenerator<'program> {
     }
 
     pub fn sync_gpu_fence(&mut self, recv_var_id: VarId) {
-        write!(self.code_writer, "instance.state.get_device_mut().poll(if let Some(id) = {} {{ wgpu::Maintain::WaitForSubmissionIndex(id) }} else {{ wgpu::Maintain::Wait }});\n", self.variable_tracker.get_var_name(recv_var_id));
+        write!(self.code_writer, "instance.state.get_device_mut().poll(if let Some(id) = {} {{ wgpu::Maintain::WaitForSubmissionIndex(id) }} else {{ wgpu::Maintain::Wait }});\n", self.get_var_name(recv_var_id));
     }
 
     pub fn insert_comment(&mut self, comment_string: &str) {
@@ -612,8 +646,10 @@ impl<'program> CodeGenerator<'program> {
 
         self.active_pipeline_name = Some(String::from(pipeline_name));
         self.code_writer.begin_module(pipeline_name);
-        write!(self.code_writer, "use caiman_rt::wgpu;\n");
-        write!(self.code_writer, "use caiman_rt::bytemuck;\n");
+        write!(
+            self.code_writer,
+            "use caiman_rt::{{LocalVars, GpuLocals, wgpu, bytemuck}};\n"
+        );
 
         self.code_writer.begin_module("outputs");
         {
@@ -680,8 +716,9 @@ impl<'program> CodeGenerator<'program> {
         let mut next_trait_index = 0usize;
 
         let mut argument_variable_ids = Vec::<VarId>::new();
-        write!(self.code_writer, "fn funclet{}_func<'state,  'cpu_functions, 'callee, Callbacks : CpuFunctions>(instance : Instance<'state, 'cpu_functions, Callbacks>, join_stack : &mut caiman_rt::JoinStack<'callee>", funclet_id);
+        write!(self.code_writer, "fn funclet{}_func<'state,  'cpu_functions, 'callee, Callbacks : CpuFunctions>(mut instance : Instance<'state, 'cpu_functions, Callbacks>, join_stack : &mut caiman_rt::JoinStack<'callee>", funclet_id);
 
+        let mut inputs = Vec::new();
         for (input_index, input_type) in input_types.iter().enumerate() {
             write!(self.code_writer, ", ");
 
@@ -692,16 +729,17 @@ impl<'program> CodeGenerator<'program> {
                 ffi::Type::GpuBufferAllocator => true,
                 _ => false,
             };
+            inputs.push((variable_id, input_type));
             if is_mutable {
                 self.code_writer.write(format!(
                     "mut {} : {}",
-                    self.variable_tracker.get_var_name(variable_id),
+                    self.get_var_name(variable_id),
                     type_name
                 ));
             } else {
                 self.code_writer.write(format!(
                     "{} : {}",
-                    self.variable_tracker.get_var_name(variable_id),
+                    self.get_var_name(variable_id),
                     type_name
                 ));
             }
@@ -801,7 +839,12 @@ impl<'program> CodeGenerator<'program> {
         write!(self.code_writer, "}}");
 
         // Write the instance state
-        write!(self.code_writer, "pub struct Instance<'state, 'cpu_functions, F : CpuFunctions>{{state : & 'state mut dyn caiman_rt::State, cpu_functions : & 'cpu_functions F");
+        write!(
+            self.code_writer,
+            "pub struct Instance<'state, 'cpu_functions, F : CpuFunctions>{{\
+            state : & 'state mut dyn caiman_rt::State, cpu_functions : & 'cpu_functions F, \
+            locals: LocalVars, glocals: GpuLocals"
+        );
 
         for (shader_module_key, shader_module) in self.shader_modules.iter() {
             write!(
@@ -860,7 +903,7 @@ impl<'program> CodeGenerator<'program> {
             self.code_writer,
             "{}",
             "
-				Self{state, cpu_functions"
+				Self{locals: LocalVars::new(), glocals: GpuLocals::new(state), state, cpu_functions"
         );
 
         for (shader_module_key, shader_module) in self.shader_modules.iter() {
@@ -1043,11 +1086,7 @@ impl<'program> CodeGenerator<'program> {
         );
         write!(self.code_writer, "(instance, join_stack");
         for (argument_index, var_id) in argument_var_ids.iter().enumerate() {
-            write!(
-                self.code_writer,
-                ", {}",
-                self.variable_tracker.get_var_name(*var_id)
-            );
+            write!(self.code_writer, ", {}", self.get_var_name(*var_id));
         }
         write!(self.code_writer, ")\n");
     }
@@ -1064,21 +1103,13 @@ impl<'program> CodeGenerator<'program> {
             );
             write!(self.code_writer, "(instance, join_stack");
             for (return_index, var_id) in output_var_ids.iter().enumerate() {
-                write!(
-                    self.code_writer,
-                    ", {}",
-                    self.variable_tracker.get_var_name(*var_id)
-                );
+                write!(self.code_writer, ", {}", self.get_var_name(*var_id));
             }
             write!(self.code_writer, ") }}");
         }
         write!(self.code_writer, "return FuncletResult::<'state, 'cpu_functions, 'callee, Callbacks, _> {{instance, phantom : std::marker::PhantomData::<& 'callee ()>, intermediates : FuncletResultIntermediates::<_>::Return((");
         for (return_index, var_id) in output_var_ids.iter().enumerate() {
-            write!(
-                self.code_writer,
-                "{}, ",
-                self.variable_tracker.get_var_name(*var_id)
-            );
+            write!(self.code_writer, "{}, ", self.get_var_name(*var_id));
         }
         write!(self.code_writer, "))}};");
     }
@@ -1090,11 +1121,7 @@ impl<'program> CodeGenerator<'program> {
     ) {
         write!(self.code_writer, "return FuncletResult::<'state, 'cpu_functions, 'callee, Callbacks, _> {{instance, phantom : std::marker::PhantomData::<& 'callee ()>, intermediates : FuncletResultIntermediates::<_>::Yield{}{{ yielded : (", yield_point_id.0);
         for (return_index, var_id) in yielded_var_ids.iter().enumerate() {
-            write!(
-                self.code_writer,
-                "{}, ",
-                self.variable_tracker.get_var_name(*var_id)
-            );
+            write!(self.code_writer, "{}, ", self.get_var_name(*var_id));
         }
         write!(self.code_writer, ") }} }};");
     }
@@ -1180,6 +1207,17 @@ impl<'program> CodeGenerator<'program> {
         self.native_interface.calculate_type_binding_info(type_id)
     }
 
+    /// Returns true if the type is a reference type
+    fn is_ref(&self, type_id: ffi::TypeId) -> bool {
+        match &self.native_interface.types[type_id.0] {
+            ffi::Type::ConstRef { .. }
+            | ffi::Type::MutRef { .. }
+            | ffi::Type::ConstSlice { .. }
+            | ffi::Type::MutSlice { .. } => true,
+            _ => false,
+        }
+    }
+
     fn get_type_name(&self, type_id: ffi::TypeId) -> String {
         match &self.native_interface.types[type_id.0] {
             ffi::Type::F32 => "f32".to_string(),
@@ -1221,6 +1259,23 @@ impl<'program> CodeGenerator<'program> {
             ffi::Type::GpuFence => format!("caiman_rt::GpuFence"),
             _ => format!("type_{}", type_id.0),
         }
+    }
+
+    fn get_stripped_type_name(&self, type_id: ffi::TypeId) -> String {
+        match &self.native_interface.types[type_id.0] {
+            ffi::Type::ConstRef { element_type } => self.get_type_name(*element_type),
+            ffi::Type::MutRef { element_type } => self.get_type_name(*element_type),
+            ffi::Type::ConstSlice { element_type } => self.get_type_name(*element_type),
+            ffi::Type::MutSlice { element_type } => self.get_type_name(*element_type),
+            ffi::Type::GpuBufferRef { element_type } => self.get_type_name(*element_type),
+            ffi::Type::GpuBufferSlice { element_type } => self.get_type_name(*element_type),
+            _ => self.get_type_name(type_id),
+        }
+    }
+
+    fn get_stripped_var_type_name(&self, var_id: VarId) -> String {
+        let type_id = self.variable_tracker.variable_types[&var_id];
+        self.get_stripped_type_name(type_id)
     }
 
     pub fn create_ffi_type(&mut self, typ: ffi::Type) -> ffi::TypeId {
@@ -1271,40 +1326,22 @@ impl<'program> CodeGenerator<'program> {
         }
     }
 
-    pub fn build_constant_integer(&mut self, value: i64, type_id: ffi::TypeId) -> VarId {
-        let variable_id = self.variable_tracker.create_local_data(Some(type_id));
+    fn build_const_int(&mut self, value: String, typ: &str, type_id: ffi::TypeId) -> VarId {
+        let variable_id = self.variable_tracker.create_local_alloc(Some(type_id));
         write!(
             self.code_writer,
-            "let {} : {} = {};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.get_type_name(type_id),
-            value
+            "instance.locals.calloc::<{typ}>({}, {value});\n",
+            variable_id.0
         );
         variable_id
     }
 
-    pub fn build_constant_i32(&mut self, value: i32, type_id: ffi::TypeId) -> VarId {
-        let variable_id = self.variable_tracker.create_local_data(Some(type_id));
-        write!(
-            self.code_writer,
-            "let {} : {} = {};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.get_type_name(type_id),
-            value
-        );
-        variable_id
-    }
-
-    pub fn build_constant_unsigned_integer(&mut self, value: u64, type_id: ffi::TypeId) -> VarId {
-        let variable_id = self.variable_tracker.create_local_data(Some(type_id));
-        write!(
-            self.code_writer,
-            "let {} : {} = {};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.get_type_name(type_id),
-            value
-        );
-        variable_id
+    pub fn build_constant_int<T: ToString>(&mut self, value: T, type_id: ffi::TypeId) -> VarId {
+        self.build_const_int(
+            value.to_string(),
+            &self.get_stripped_type_name(type_id),
+            type_id,
+        )
     }
 
     pub fn build_select_hack(
@@ -1327,10 +1364,10 @@ impl<'program> CodeGenerator<'program> {
         write!(
             self.code_writer,
             "let {} = if {} != 0 {{ {} }} else {{ {} }};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.variable_tracker.get_var_name(condition_var_id),
-            self.variable_tracker.get_var_name(true_case_var_id),
-            self.variable_tracker.get_var_name(false_case_var_id)
+            self.get_var_name(variable_id),
+            self.get_var_name(condition_var_id),
+            self.get_var_name(true_case_var_id),
+            self.get_var_name(false_case_var_id)
         );
         variable_id
     }
@@ -1347,34 +1384,37 @@ impl<'program> CodeGenerator<'program> {
         let mut var_names = Vec::<String>::new();
         let mut var_types = Vec::<String>::new();
         for (i, type_id) in output_type_ids.iter().enumerate() {
-            let var_id = self.variable_tracker.create_local_data(Some(*type_id));
-            var_names.push(self.variable_tracker.get_var_name(var_id));
-            var_types.push(self.get_type_name(*type_id));
+            let var_id = self.variable_tracker.create_local_alloc(Some(*type_id));
+            var_types.push(self.get_stripped_type_name(*type_id));
             var_ids.push(var_id);
         }
 
-        write!(self.code_writer, "let ( ");
+        write!(self.code_writer, "( ");
 
-        for (i, var_name) in var_names.iter().enumerate() {
-            write!(self.code_writer, "{}", var_name);
+        for (i, (var_id, var_type)) in var_ids.iter().zip(var_types).enumerate() {
+            write!(
+                self.code_writer,
+                "*instance.locals.malloc::<{var_type}>({})",
+                var_id.0,
+            );
             if i < output_type_ids.len() - 1 {
                 write!(self.code_writer, ", ");
             }
         }
 
-        write!(self.code_writer, " ) : ( ");
+        // write!(self.code_writer, " ) : ( ");
 
-        for (i, var_type) in var_types.iter().enumerate() {
-            write!(self.code_writer, "{}", var_type);
-            if i < output_type_ids.len() - 1 {
-                write!(self.code_writer, ", ");
-            }
-        }
+        // for (i, var_type) in var_types.iter().enumerate() {
+        //     write!(self.code_writer, "{}", var_type);
+        //     if i < output_type_ids.len() - 1 {
+        //         write!(self.code_writer, ", ");
+        //     }
+        // }
 
         write!(
             self.code_writer,
-            " ) = if {} !=0 {{ ",
-            self.variable_tracker.get_var_name(condition_var_id)
+            ") = if {} !=0 {{ ",
+            self.get_var_name(condition_var_id)
         );
 
         var_ids.into_boxed_slice()
@@ -1386,11 +1426,9 @@ impl<'program> CodeGenerator<'program> {
 
         write!(self.code_writer, " ( ");
         for (i, var_id) in output_var_ids.iter().enumerate() {
-            write!(
-                self.code_writer,
-                "{}",
-                self.variable_tracker.get_var_name(*var_id)
-            );
+            let typ_name =
+                self.get_stripped_type_name(self.variable_tracker.variable_types[var_id]);
+            write!(self.code_writer, "{}", self.access_val_str(*var_id));
             if i < output_var_ids.len() - 1 {
                 write!(self.code_writer, ", ");
             }
@@ -1401,11 +1439,9 @@ impl<'program> CodeGenerator<'program> {
     pub fn end_else(&mut self, output_var_ids: &[VarId]) {
         write!(self.code_writer, " ( ");
         for (i, var_id) in output_var_ids.iter().enumerate() {
-            write!(
-                self.code_writer,
-                "{}",
-                self.variable_tracker.get_var_name(*var_id)
-            );
+            let typ_name =
+                self.get_stripped_type_name(self.variable_tracker.variable_types[var_id]);
+            write!(self.code_writer, "{}", self.access_val_str(*var_id));
             if i < output_var_ids.len() - 1 {
                 write!(self.code_writer, ", ");
             }
@@ -1428,41 +1464,50 @@ impl<'program> CodeGenerator<'program> {
         let call_result_var = self.variable_tracker.generate();
         let mut argument_string = String::new();
         for (index, argument) in argument_vars.iter().enumerate() {
-            argument_string +=
-                format!("{}", self.variable_tracker.get_var_name(*argument)).as_str();
+            let src = if self.variable_tracker.is_temp(*argument) {
+                format!("{}", self.access_val_str(*argument),)
+            } else {
+                format!("{}", self.get_var_name(*argument))
+            };
+            argument_string += &src;
             if index + 1 < argument_vars.len() {
                 argument_string += ", ";
             }
         }
         self.code_writer.write(format!(
             "let {} = instance.cpu_functions.{}(instance.state, {});\n",
-            self.variable_tracker.get_var_name(call_result_var),
+            self.get_var_name(call_result_var),
             external_cpu_function.name,
             argument_string
         ));
         let mut output_variables = Vec::<VarId>::new();
         for (i, output_type) in external_cpu_function.output_types.iter().enumerate() {
-            let var = self.variable_tracker.create_local_data(Some(*output_type));
+            let var = self.variable_tracker.create_local_alloc(Some(*output_type));
             output_variables.push(var);
             self.code_writer.write(format!(
-                "let {} = {}.{};\n",
-                self.variable_tracker.get_var_name(var),
-                self.variable_tracker.get_var_name(call_result_var),
+                "*instance.locals.calloc::<{}>({}, {}.{});\n",
+                self.get_stripped_type_name(*output_type),
+                var.0,
+                self.get_var_name(call_result_var),
                 i
             ));
         }
         output_variables.into_boxed_slice()
     }
 
-    pub fn build_create_buffer(
+    pub fn build_alloc_temp_gpu(
         &mut self,
         type_id: ffi::TypeId,
         buffer_flags: ir::BufferFlags,
     ) -> VarId {
-        let variable_id = self.variable_tracker.create_buffer(Some(type_id));
+        let variable_id = self.variable_tracker.create_local_gpu(Some(type_id));
         let type_binding_info = self.get_type_binding_info(type_id);
-        let type_name = self.get_type_name(type_id);
-        write!(self.code_writer, "let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage: wgpu::BufferUsages::empty()", self.variable_tracker.get_var_name(variable_id), type_binding_info.size);
+        let type_name = self.get_stripped_type_name(type_id);
+        write!(
+            self.code_writer,
+            "instance.glocals.alloc_gpu::<{type_name}>({}, wgpu::BufferUsages::empty()",
+            variable_id.0
+        );
         if buffer_flags.map_read {
             write!(self.code_writer, " | wgpu::BufferUsages::MAP_READ");
         }
@@ -1481,29 +1526,13 @@ impl<'program> CodeGenerator<'program> {
         if buffer_flags.uniform {
             write!(self.code_writer, " | wgpu::BufferUsages::UNIFORM");
         }
-        write!(self.code_writer, ", mapped_at_creation : false}});\n");
-        //self.code_writer.write(format!("let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage : wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE, mapped_at_creation : false}});\n", self.variable_tracker.get_var_name(variable_id), type_binding_info.size));
+        write!(self.code_writer, ");\n");
+        //self.code_writer.write(format!("let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage : wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE, mapped_at_creation : false}});\n", self.get_var_name(variable_id), type_binding_info.size));
         variable_id
     }
 
-    pub fn build_buffer_ref(
-        &mut self,
-        buffer_var_id: VarId,
-        offset_var_id: VarId,
-        type_id: ffi::TypeId,
-    ) -> VarId {
-        let variable_id = self.variable_tracker.create_local_data(None);
-        let type_binding_info = self.get_type_binding_info(type_id);
-        let type_name = self.get_type_name(type_id);
-        write!(
-            self.code_writer,
-            "let {} = caiman_rt::GpuBufferRef::<'_, {}>::new(& {}, {});\n",
-            self.variable_tracker.get_var_name(variable_id),
-            type_name,
-            self.variable_tracker.get_var_name(buffer_var_id),
-            self.variable_tracker.get_var_name(offset_var_id)
-        );
-        variable_id
+    pub fn build_buffer_ref(&mut self, buffer_var_id: VarId, type_id: ffi::TypeId) -> VarId {
+        buffer_var_id
     }
 
     pub fn build_buffer_suballocate_ref(
@@ -1511,14 +1540,15 @@ impl<'program> CodeGenerator<'program> {
         buffer_allocator_var_id: VarId,
         type_id: ffi::TypeId,
     ) -> VarId {
+        todo!();
         let variable_id = self.variable_tracker.create_local_data(None);
         let type_binding_info = self.get_type_binding_info(type_id);
         let type_name = self.get_type_name(type_id);
         write!(
             self.code_writer,
             "let {} = {}.suballocate_ref::<'callee, {}>().unwrap();\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.variable_tracker.get_var_name(buffer_allocator_var_id),
+            self.get_var_name(variable_id),
+            self.get_var_name(buffer_allocator_var_id),
             type_name
         );
         variable_id
@@ -1530,16 +1560,17 @@ impl<'program> CodeGenerator<'program> {
         type_id: ffi::TypeId,
         count_var_id: VarId,
     ) -> VarId {
+        todo!();
         let variable_id = self.variable_tracker.create_local_data(None);
         let type_binding_info = self.get_type_binding_info(type_id);
         let type_name = self.get_type_name(type_id);
         write!(
             self.code_writer,
             "let {} = {}.suballocate_slice::<'callee, {}>({}).unwrap();\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.variable_tracker.get_var_name(buffer_allocator_var_id),
+            self.get_var_name(variable_id),
+            self.get_var_name(buffer_allocator_var_id),
             type_name,
-            self.variable_tracker.get_var_name(count_var_id)
+            self.get_var_name(count_var_id)
         );
         variable_id
     }
@@ -1549,6 +1580,7 @@ impl<'program> CodeGenerator<'program> {
         buffer_allocator_var_id: VarId,
         type_id_and_count_var_id_pairs: &[(ffi::TypeId, Option<VarId>)],
     ) -> VarId {
+        todo!();
         let mut layouts_string = String::from("");
         let mut element_counts_string = String::from("");
 
@@ -1563,7 +1595,7 @@ impl<'program> CodeGenerator<'program> {
                 write!(
                     element_counts_string,
                     "Some({}), ",
-                    self.variable_tracker.get_var_name(*count_var_id)
+                    self.get_var_name(*count_var_id)
                 );
             } else {
                 write!(element_counts_string, "None, ");
@@ -1574,8 +1606,8 @@ impl<'program> CodeGenerator<'program> {
         write!(
             self.code_writer,
             "let {} = {}.test_suballocate_many(&[{}], &[{}]);\n",
-            self.variable_tracker.get_var_name(success_var_id),
-            self.variable_tracker.get_var_name(buffer_allocator_var_id),
+            self.get_var_name(success_var_id),
+            self.get_var_name(buffer_allocator_var_id),
             layouts_string,
             element_counts_string
         );
@@ -1607,11 +1639,7 @@ impl<'program> CodeGenerator<'program> {
             capture_types.len()
         );
         for var_id in capture_var_ids.iter() {
-            write!(
-                self.code_writer,
-                "{}, ",
-                self.variable_tracker.get_var_name(*var_id)
-            );
+            write!(self.code_writer, "{}, ", self.get_var_name(*var_id));
         }
         write!(self.code_writer, "); let closure_header = ClosureHeader::Funclet{}Capturing{}; unsafe {{ join_stack.push_unsafe_unaligned(join_data).expect(\"Ran out of memory while serializing join\"); join_stack.push_unsafe_unaligned(closure_header).expect(\"Ran out of memory while serializing join\"); }}", funclet_id, capture_types.len());
 
@@ -1634,41 +1662,42 @@ impl<'program> CodeGenerator<'program> {
 
         let output_var_id = self.variable_tracker.create_local_data(Some(type_id));
 
+        self.code_writer
+            .write(format!("let {} = {{\n", self.get_var_name(output_var_id)));
         self.code_writer.write(format!(
             "let {} = {}.slice();\n",
-            self.variable_tracker.get_var_name(slice_var_id),
-            self.variable_tracker.get_var_name(source_var)
+            self.get_var_name(slice_var_id),
+            self.build_get_gpu_ref(source_var, None)
         ));
         self.code_writer.write(format!(
             "let ({0}_send, {0}_recv) = futures::channel::oneshot::channel::<()>();\n",
-            self.variable_tracker.get_var_name(future_var_id)
+            self.get_var_name(future_var_id)
         ));
-        self.code_writer.write(format!("{1}.map_async(wgpu::MapMode::Read, |res| {{res.unwrap(); {0}_send.send(()).unwrap(); }});\n", self.variable_tracker.get_var_name(future_var_id), self.variable_tracker.get_var_name(slice_var_id)));
+        self.code_writer.write(format!("{1}.map_async(wgpu::MapMode::Read, |res| {{res.unwrap(); {0}_send.send(()).unwrap(); }});\n", self.get_var_name(future_var_id), self.get_var_name(slice_var_id)));
         self.code_writer.write(format!(
             "instance.state.get_device_mut().poll(wgpu::Maintain::Wait);\n"
         ));
         self.code_writer.write(format!(
             "futures::executor::block_on({}_recv);\n",
-            self.variable_tracker.get_var_name(future_var_id)
+            self.get_var_name(future_var_id)
         ));
         self.code_writer.write(format!(
             "let {} = {}.get_mapped_range();\n",
-            self.variable_tracker.get_var_name(range_var_id),
-            self.variable_tracker.get_var_name(slice_var_id)
+            self.get_var_name(range_var_id),
+            self.get_var_name(slice_var_id)
         ));
         self.code_writer.write(format!(
-            "let {} = * unsafe {{ std::mem::transmute::<* const u8, & {}>({}.as_ptr()) }};\n",
-            self.variable_tracker.get_var_name(output_var_id),
+            "*unsafe {{ std::mem::transmute::<* const u8, & {}>({}.as_ptr()) }}\n",
             type_name,
-            self.variable_tracker.get_var_name(range_var_id)
+            self.get_var_name(range_var_id)
         ));
+        self.code_writer.write(String::from("};\n"));
         return output_var_id;
     }
 
     /// Returns a string representing variable `var` as a slice of little-endian bytes.
     fn local_as_le_bytes(&self, var: VarId, var_type_id: ffi::TypeId) -> String {
         use ffi::Type::*;
-        let var_name = self.variable_tracker.get_var_name(var);
         //let var_type_id = self.variable_tracker.get_type_id(var);
         let var_type = self.native_interface.types.get(var_type_id.0).unwrap();
 
@@ -1676,19 +1705,19 @@ impl<'program> CodeGenerator<'program> {
         // doing the bare minimum to get this working
         match var_type {
             F32 | F64 | U8 | U16 | U32 | U64 | USize | I8 | I16 | I32 | I64 => {
-                return format!("&{}.to_le_bytes()", var_name)
+                return format!("&{}.to_le_bytes()", self.access_val_str(var),)
             }
             Array {
                 element_type,
                 length,
-            } => return format!("bytemuck::cast_slice(&{})", var_name),
+            } => return format!("bytemuck::cast_slice(&{})", self.access_val_str(var)),
             _ => panic!("type {:?} not yet supported", var_type),
         }
     }
 
     fn local_ref_content_as_le_bytes(&self, var: VarId, var_type_id: ffi::TypeId) -> String {
         use ffi::Type::*;
-        let var_name = self.variable_tracker.get_var_name(var);
+        let var_name = self.get_var_name(var);
         //let var_type_id = self.variable_tracker.get_type_id(var);
         let var_type = self.native_interface.types.get(var_type_id.0).unwrap();
         let data_type_id = match var_type {
@@ -1712,14 +1741,38 @@ impl<'program> CodeGenerator<'program> {
         }
     }
 
+    /// Builds a string which represents the Rust code for getting a reference to
+    /// the GPU buffer for the given variable.
+    /// If the variable is a temporary, this will be a call to `instance.glocals.get_gpu_ref`.
+    /// If the variable is not a temporary, this will be the variable name itself.
+    /// # Arguments
+    /// * `var` - The variable to get the GPU buffer reference for
+    /// * `type_id` - The type of the variable, if known. If `None`, the type will be looked up
+    ///  from the variable tracker.
+    fn build_get_gpu_ref(&self, var: VarId, type_id: Option<ffi::TypeId>) -> String {
+        if self.variable_tracker.is_temp(var) {
+            let type_name = type_id
+                .map(|x| self.get_type_name(x))
+                .unwrap_or_else(|| self.get_stripped_var_type_name(var));
+            format!("instance.glocals.get_gpu_ref::<{type_name}>({})", var.0)
+        } else {
+            self.get_var_name(var)
+        }
+    }
+
     pub fn encode_copy_buffer_from_local_data(
         &mut self,
         destination_var: VarId,
         source_var: VarId,
         type_id: ffi::TypeId,
     ) {
-        let buffer_view_var_name = self.variable_tracker.get_var_name(destination_var);
+        let buffer_view_var_name = self.get_var_name(destination_var);
         let source_bytes = self.local_as_le_bytes(source_var, type_id);
+        self.code_writer.write(format!(
+            "let {} = {};\n",
+            buffer_view_var_name,
+            self.build_get_gpu_ref(destination_var, Some(type_id))
+        ));
         self.code_writer.write(format!(
             "instance.state.get_queue_mut().write_buffer({}.buffer, {}.base_address, {});\n",
             buffer_view_var_name, buffer_view_var_name, source_bytes
@@ -1735,12 +1788,14 @@ impl<'program> CodeGenerator<'program> {
         //let type_id = self.variable_tracker.get_type_id(source_var);
         //assert_eq!(type_id, self.variable_tracker.get_type_id(destination_var));
         let type_binding_info = self.get_type_binding_info(type_id);
+        let type_name = self.get_type_name(type_id);
         self.begin_command_encoding();
         write!(
             self.code_writer,
-            "command_encoder.copy_buffer_to_buffer(& {}, 0, & {}, 0, {});\n",
-            self.variable_tracker.get_var_name(destination_var),
-            self.variable_tracker.get_var_name(source_var),
+            "command_encoder.copy_buffer_to_buffer(& {}, 0, \
+                & {}, 0, {});\n",
+            self.build_get_gpu_ref(destination_var, Some(type_id)),
+            self.build_get_gpu_ref(source_var, Some(type_id)),
             type_binding_info.size
         );
         let command_buffer_id = self.end_command_encoding();
@@ -1750,9 +1805,9 @@ impl<'program> CodeGenerator<'program> {
     /*fn build_create_buffer_with_data(&mut self, data_var: VarId, type_id: ffi::TypeId, buffer_flags : ir::BufferFlags) -> VarId {
         let variable_id = self.variable_tracker.generate();
         let type_binding_info = self.get_type_binding_info(type_id);
-        let buffer_view_var_name = self.variable_tracker.get_var_name(variable_id);
+        let buffer_view_var_name = self.get_var_name(variable_id);
         let data_bytes = self.local_as_le_bytes(data_var, type_id);
-        self.code_writer.write(format!("let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage : wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE, mapped_at_creation : false}});\n", self.variable_tracker.get_var_name(variable_id), type_binding_info.size));
+        self.code_writer.write(format!("let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage : wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE, mapped_at_creation : false}});\n", self.get_var_name(variable_id), type_binding_info.size));
         self.code_writer.write(format!(
             "instance.state.get_queue_mut().write_buffer(& {}.buffer, {}.base_address, {} );\n",
             buffer_view_var_name, buffer_view_var_name, data_bytes
@@ -1769,14 +1824,14 @@ impl<'program> CodeGenerator<'program> {
         let variable_id = self.variable_tracker.generate();
         let type_binding_info = self.get_type_binding_info(type_id);
         let type_name = self.get_type_name(type_id);
-        self.code_writer.write(format!("let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage : wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE, mapped_at_creation : false}});\n", self.variable_tracker.get_var_name(variable_id), type_binding_info.size));
+        self.code_writer.write(format!("let mut {} = instance.state.get_device_mut().create_buffer(& wgpu::BufferDescriptor {{ label : None, size : {}, usage : wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE, mapped_at_creation : false}});\n", self.get_var_name(variable_id), type_binding_info.size));
         write!(self.code_writer, "{{\n");
         self.code_writer.write("let mut command_encoder = instance.state.get_device_mut().create_command_encoder(& wgpu::CommandEncoderDescriptor {label : None});\n".to_string());
         write!(
             self.code_writer,
             "command_encoder.copy_buffer_to_buffer(& {}, 0, & {}, 0, {});\n",
-            self.variable_tracker.get_var_name(data_var),
-            self.variable_tracker.get_var_name(variable_id),
+            self.get_var_name(data_var),
+            self.get_var_name(variable_id),
             type_binding_info.size
         );
         self.code_writer
@@ -1808,42 +1863,96 @@ impl<'program> CodeGenerator<'program> {
     }
 
     pub fn build_alloc_temp_local_ref(&mut self, type_id: ffi::TypeId) -> VarId {
-        let variable_id = self.variable_tracker.create_local_data(Some(type_id));
-        let temp_var_id = self.variable_tracker.generate();
-        //let type_binding_info = self.get_type_binding_info(type_id);
-        let type_name = self.get_type_name(type_id);
+        let variable_id = self.variable_tracker.create_local_alloc(Some(type_id));
+        let type_name = self.get_stripped_type_name(type_id);
         write!(
             self.code_writer,
-            "let mut {} : {} = std::default::Default::default();\n",
-            self.variable_tracker.get_var_name(temp_var_id),
-            type_name
-        );
-        write!(
-            self.code_writer,
-            "let {} = &mut {};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.variable_tracker.get_var_name(temp_var_id)
+            "instance.locals.malloc::<{type_name}>({});\n",
+            variable_id.0,
         );
         variable_id
     }
 
     pub fn build_write_local_ref(&mut self, dst_ref_var_id: VarId, src_var_id: VarId) {
-        write!(
-            self.code_writer,
-            "* {} = {};\n",
-            self.variable_tracker.get_var_name(dst_ref_var_id),
-            self.variable_tracker.get_var_name(src_var_id)
-        );
+        let src = if self.variable_tracker.is_temp(src_var_id) {
+            // safe bc of the caiman type system
+            format!(
+                "*instance.locals.get::<{}>({})",
+                self.get_stripped_var_type_name(src_var_id),
+                src_var_id.0,
+            )
+        } else {
+            self.get_var_name(src_var_id)
+        };
+        if self.variable_tracker.is_temp(dst_ref_var_id) {
+            // this should be safe bc of the caiman type system
+            write!(
+                self.code_writer,
+                "*instance.locals.get_mut::<{}>({}) = {};\n",
+                self.get_stripped_var_type_name(dst_ref_var_id),
+                dst_ref_var_id.0,
+                src,
+            );
+        } else {
+            write!(
+                self.code_writer,
+                "*{} = {};\n",
+                self.get_var_name(dst_ref_var_id),
+                src,
+            );
+        }
+    }
+
+    /// Returns a string that is the code that can access the reference to a variable
+    fn access_ref_str(&self, var_id: VarId) -> String {
+        if self.variable_tracker.is_temp(var_id) {
+            // safe bc of the caiman type system
+            format!(
+                "instance.locals.get::<{}>({})",
+                self.get_stripped_var_type_name(var_id),
+                var_id.0,
+            )
+        } else if self.variable_tracker.variable_types.contains_key(&var_id)
+            && self.is_ref(self.variable_tracker.variable_types[&var_id])
+        {
+            self.get_var_name(var_id)
+        } else {
+            format!("(&{})", self.get_var_name(var_id))
+        }
+    }
+
+    /// Returns a string that is the code which can accesss the value of a variable
+    fn access_val_str(&self, var_id: VarId) -> String {
+        if self.variable_tracker.is_temp(var_id) {
+            // safe bc of the caiman type system
+            format!(
+                "(*instance.locals.get::<{}>({}))",
+                self.get_stripped_var_type_name(var_id),
+                var_id.0,
+            )
+        } else if self.variable_tracker.variable_types.contains_key(&var_id)
+            && self.is_ref(self.variable_tracker.variable_types[&var_id])
+        {
+            format!("(*{})", self.get_var_name(var_id))
+        } else {
+            self.get_var_name(var_id)
+        }
     }
 
     pub fn build_read_local_ref(&mut self, src_ref_var_id: VarId, type_id: ffi::TypeId) -> VarId {
         let variable_id = self.variable_tracker.create_local_data(Some(type_id));
-        let type_name = self.get_type_name(type_id);
         write!(
             self.code_writer,
-            "let {} = * {};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.variable_tracker.get_var_name(src_ref_var_id)
+            "let {} = {};\n",
+            self.get_var_name(variable_id),
+            self.access_val_str(src_ref_var_id)
+        );
+        write!(
+            self.code_writer,
+            "instance.locals.calloc::<{}>({}, {});\n",
+            self.get_stripped_type_name(type_id),
+            variable_id.0,
+            self.get_var_name(variable_id)
         );
         variable_id
     }
@@ -1854,8 +1963,8 @@ impl<'program> CodeGenerator<'program> {
         write!(
             self.code_writer,
             "let {} = & {};\n",
-            self.variable_tracker.get_var_name(variable_id),
-            self.variable_tracker.get_var_name(src_var_id)
+            self.get_var_name(variable_id),
+            self.get_var_name(src_var_id)
         );
         variable_id
     }

--- a/src/rust_wgpu_backend/codegen.rs
+++ b/src/rust_wgpu_backend/codegen.rs
@@ -514,7 +514,7 @@ impl<'program> CodeGen<'program> {
                     for i in dimension_var_ids.len()..3 {
                         dimension_var_ids.push(
                             self.code_generator
-                                .build_constant_unsigned_integer(1, self.default_usize_ffi_type_id),
+                                .build_constant_int(1, self.default_usize_ffi_type_id),
                         );
                     }
                 }
@@ -563,13 +563,13 @@ impl<'program> CodeGen<'program> {
                 let variable_id = match value {
                     ir::Constant::I64(value) => self
                         .code_generator
-                        .build_constant_integer(*value, storage_type_id),
+                        .build_constant_int(*value, storage_type_id),
                     ir::Constant::U64(value) => self
                         .code_generator
-                        .build_constant_unsigned_integer(*value, storage_type_id),
+                        .build_constant_int(*value, storage_type_id),
                     ir::Constant::I32(value) => self
                         .code_generator
-                        .build_constant_i32(*value, storage_type_id),
+                        .build_constant_int(*value, storage_type_id),
                 };
                 check_storage_type_implements_value_type(&self.program, storage_type_id, *type_id);
 
@@ -1305,6 +1305,7 @@ impl<'program> CodeGen<'program> {
         funclet_scoped_state: &FuncletScopedState,
         inputs: &[ir::NodeId],
     ) -> Box<[VarId]> {
+        todo!("Collect local inputs");
         let mut input_var_ids = Vec::<VarId>::new();
         for input in inputs.iter() {
             let node_result = funclet_scoped_state.get_node_result(*input).unwrap();
@@ -1413,15 +1414,10 @@ impl<'program> CodeGen<'program> {
                     ir::Place::Gpu => {
                         let buffer_var_id = self
                             .code_generator
-                            .build_create_buffer(*storage_type, *buffer_flags);
-                        let offset_var_id = self
+                            .build_alloc_temp_gpu(*storage_type, *buffer_flags);
+                        let var_id = self
                             .code_generator
-                            .build_constant_unsigned_integer(0, self.default_u64_ffi_type_id);
-                        let var_id = self.code_generator.build_buffer_ref(
-                            buffer_var_id,
-                            offset_var_id,
-                            *storage_type,
-                        );
+                            .build_buffer_ref(buffer_var_id, *storage_type);
 
                         funclet_scoped_state.node_results.insert(
                             current_node_id,


### PR DESCRIPTION
* Adds global GPU and CPU buffers to allocate temporaries from in the `instance`
* Adds to the `variable_tracker` a set to keep track of all variables which are temporaries
* Replaces `get_var_name` with a function that will create the variable name if the variable id is not considered a temporary by the `variable_tracker`. If it is a temporary, the function will generate the code to get the reference from the `instance`
* Adds a bump allocator to manage allocations in CPU and GPU buffers that respect alignment
* Adds `CPUAllocator` and `GPUAllocator` to pair the BumpAllocator with a buffer
* Adds `LocalVars` and `GPULocals` to wrap the respective allocators and manage getting references to local variables